### PR TITLE
Compatibility fix for newer autoutils.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,11 +8,10 @@ m4_define([td_version],
 AC_INIT([thermald], [td_version], [http://bugzilla.gnome.org/enter_bug_cgi?product=thermald], [thermald])
 
 AC_CONFIG_AUX_DIR(build-aux)
-AC_CONFIG_MACRO_DIR([m4])
+AC_CONFIG_HEADERS([config.h])
 
 AM_INIT_AUTOMAKE([1.11 foreign no-define])
 AM_MAINTAINER_MODE([enable])
-AM_CONFIG_HEADER(config.h)
 
 AC_ARG_WITH(dbus-sys-dir, AS_HELP_STRING([--with-dbus-sys-dir=DIR], [where D-BUS system.d directory is]))
 if test -n "$with_dbus_sys_dir" ; then


### PR DESCRIPTION
This patch fixes the build for modern versions of autotools. AM_CONFIG_HEADER has been deprecated for years and autotools 1.13 removes this macros at all. The message is:

configure.ac:15: error: 'AM_CONFIG_HEADER': this macro is obsolete.
    You should use the 'AC_CONFIG_HEADERS' macro instead.

Also AC_CONFIG_MACRO_DIR has been deleted because there is not m4 folder included in distro. This causes an error:

aclocal-1.13: error: couldn't open directory 'm4': No such file or directory

Testing:
1. Builds on gentoo.
2. Builds on RHEL 6.4.
