### PR TITLE
fix out-of-source build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ include $(GLIB_MAKEFILE)
 
 SUBDIRS = data
 
-INCLUDES= -I@top_srcdir@
+INCLUDES= -I@top_srcdir@/src
 
 ACLOCAL_AMFLAGS = 
 


### PR DESCRIPTION
without 'src' INCLUDES= -I@top_srcdir@ produces empty '-I'
statement, so that thermald.h can't be found during
compilation

Signed-off-by: Yegor Yefremov yegorslists@googlemail.com
