### PR TITLE
Specify bash shell

### DIFF
--- a/src/thd_cdev.cpp
+++ b/src/thd_cdev.cpp
@@ -277,7 +277,6 @@ int cthd_cdev::thd_cdev_set_state(int set_point, int target_temp,
 	} else if (pid_enable) {
 		pid_ctrl.set_target_temp(target_temp);
 		ret = pid_ctrl.pid_output(temperature);
-		ret += get_curr_state();
 		if (ret > get_max_state())
 			ret = get_max_state();
 		if (ret < get_min_state())

--- a/src/thd_pid.cpp
+++ b/src/thd_pid.cpp
@@ -44,7 +44,7 @@ int cthd_pid::pid_output(unsigned int curr_temp) {
 
 	int error = curr_temp - target_temp;
 	thd_log_debug("pid_output error %d %g:%g\n", error, kp, kp * error);
-	err_sum += (error * timeChange);
+	err_sum += 0.5 * (error + last_err) * timeChange;
 	if (timeChange)
 		d_err = (error - last_err) / timeChange;
 	else

--- a/tools/thermald_set_pref.sh
+++ b/tools/thermald_set_pref.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "****thermald preference****"
 echo "0 : DEFAULT"


### PR DESCRIPTION
Bash test brackets are used, so bash should be specified. This has caused problems on my system before.