### PR TITLE
fix cdev state error while trip point is off

### DIFF
--- a/src/thd_cdev.cpp
+++ b/src/thd_cdev.cpp
@@ -258,6 +258,8 @@ int cthd_cdev::thd_cdev_set_state(int set_point, int target_temp,
 				if (_target_state_valid)
 					target_value = get_min_state();
 			}
+		} else {
+			target_state_valid = 0;
 		}
 	}
 


### PR DESCRIPTION
When the trip point is off, it will call thd_cdev_set_state(state=0)
to update cdev state.

if zone_trip_limits.size() == 0, it means all trip points using this cdev
are off. It needs to set this cdev to min state (target_state_valid = 0).

Signed-off-by: Bin Yang <bin.yang@intel.com>