### PR TITLE
Use correct format specifier for size_t

### DIFF
--- a/src/thd_zone.cpp
+++ b/src/thd_zone.cpp
@@ -103,7 +103,7 @@ int cthd_zone::read_user_set_psv_temp() {
 }
 
 void cthd_zone::sort_and_update_poll_trip() {
-	thd_log_debug("sort_and_update_poll_trip: trip_points_size =%lu\n",
+	thd_log_debug("sort_and_update_poll_trip: trip_points_size =%zu\n",
 			trip_points.size());
 	if (trip_points.size()) {
 		unsigned int polling_trip = 0;


### PR DESCRIPTION
%zu instead of %lu, otherwise on 32 bit:

| ../git/src/thd_zone.cpp: In member function 'void cthd_zone::sort_and_update_poll_trip()':
| ../git/src/thd_zone.cpp:106:16: error: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'std::vector<cthd_trip_point>::size_type' {aka 'unsigned int'} [-Werror=format=]
|   thd_log_debug("sort_and_update_poll_trip: trip_points_size =%lu\n",
|                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|     trip_points.size());