### PR TITLE
Klockwork: Modified the code with NULL checks for xml parsed output.

### DIFF
--- a/src/thd_cpu_default_binding.cpp
+++ b/src/thd_cpu_default_binding.cpp
@@ -254,6 +254,10 @@ void cthd_cpu_default_binding::do_default_binding(
 	for (unsigned int i = 0; i < thd_engine->get_zone_count(); ++i) {
 		cthd_zone *zone = thd_engine->get_zone(i);
 
+		if (!zone) {
+			continue;
+		}
+
 		if (blacklist_match(zone->get_zone_type())) {
 			continue;
 		}

--- a/src/thd_parse.cpp
+++ b/src/thd_parse.cpp
@@ -192,6 +192,11 @@ int cthd_parse::parse_new_trip_point(xmlNode * a_node, xmlDoc *doc,
 			DEBUG_PARSER_PRINT("node type: Element, name: %s value: %s\n", cur_node->name, xmlNodeListGetString(doc, cur_node->xmlChildrenNode, 1));
 			tmp_value = (char *) xmlNodeListGetString(doc,
 					cur_node->xmlChildrenNode, 1);
+
+			if (!tmp_value) {
+				continue;
+			}
+
 			if (!strcasecmp((const char*) cur_node->name, "Temperature")) {
 				trip_pt->temperature = atoi(tmp_value);
 			} else if (!strcasecmp((const char*) cur_node->name,
@@ -236,9 +241,7 @@ int cthd_parse::parse_new_trip_point(xmlNode * a_node, xmlDoc *doc,
 				parse_dependency_values(cur_node->children, doc,
 						&trip_pt->dependency);
 			}
-
-			if (tmp_value)
-				xmlFree(tmp_value);
+			xmlFree(tmp_value);
 		}
 	}
 
@@ -535,6 +538,11 @@ int cthd_parse::parse_new_platform_info(xmlNode * a_node, xmlDoc *doc,
 			DEBUG_PARSER_PRINT("node type: Element, name: %s value: %s\n", cur_node->name, xmlNodeListGetString(doc, cur_node->xmlChildrenNode, 1));
 			tmp_value = (char*) xmlNodeListGetString(doc,
 					cur_node->xmlChildrenNode, 1);
+
+			if (!tmp_value) {
+				continue;
+			}
+
 			if (!strcasecmp((const char*) cur_node->name, "uuid")) {
 				info_ptr->uuid.assign((const char*) tmp_value);
 				string_trim(info_ptr->uuid);
@@ -565,8 +573,7 @@ int cthd_parse::parse_new_platform_info(xmlNode * a_node, xmlDoc *doc,
 				"PollingInterval")) {
 				info_ptr->polling_interval = atoi(tmp_value);
 			}
-			if (tmp_value)
-				xmlFree(tmp_value);
+			xmlFree(tmp_value);
 		}
 	}
 


### PR DESCRIPTION
thd_parse.cpp: parse_new_platform_info and parse_new_trip_point
executed the initializations without the NULL check of xml node
parse result. Added null check for xml parsed output.

thd_cpu_default_binding.cpp: thd_engine->get_zone could potentially
return NULL and the function do_default_binding could dereference
a NULL pointer. Hence, added a NULL check for zone.

Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>