### PR TITLE
Android: Changing the conf dir to 'vendor' instead of 'misc'

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -44,7 +44,7 @@ LOCAL_C_INCLUDES += external/libxml2/include
 
 LOCAL_PROPRIETARY_MODULE := true
 LOCAL_CFLAGS := \
-		-DTDRUNDIR='"/data/misc/thermal-daemon"'\
+		-DTDRUNDIR='"/data/vendor/thermal-daemon"'\
 		-DTDCONFDIR='"/system/vendor/etc/thermal-daemon"'\
 		-Wno-unused-parameter\
 		-Wall\

--- a/src/android_main.cpp
+++ b/src/android_main.cpp
@@ -241,8 +241,8 @@ int main(int argc, char *argv[]) {
 	}
 	mkdir(TDCONFDIR, 0755); // Don't care return value as directory
 	if (!no_daemon) {
-		daemonize((char *) "/data/misc/thermal-daemon",
-				(char *) "/data/misc/thermal-daemon/thermald.pid");
+		daemonize((char *) "/data/vendor/thermal-daemon",
+				(char *) "/data/vendor/thermal-daemon/thermald.pid");
 	} else
 		signal(SIGINT, signal_handler);
 


### PR DESCRIPTION
As per the new VNDK rules, vendor applications are expected to use
/data/vendor partition for all the data files.
Previously, the data files were created in /data/misc folder which
caused cts failures. Hence moving the data files creation to
/data/vendor partition.

Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>