### PR TITLE
Adding changes in the static library link and headers for VNDK compliance

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -51,7 +51,7 @@ LOCAL_CFLAGS := \
 		-Werror
 
 LOCAL_STATIC_LIBRARIES := libxml2
-LOCAL_SHARED_LIBRARIES := liblog libcutils libdl libc++ libicuuc libutils
+LOCAL_SHARED_LIBRARIES := liblog libcutils libdl libc++ libutils
 LOCAL_PRELINK_MODULE := false
 LOCAL_MODULE := thermal-daemon
 include $(BUILD_EXECUTABLE)

--- a/src/android_main.cpp
+++ b/src/android_main.cpp
@@ -38,7 +38,7 @@
 #   define   getdtablesize()	(_POSIX_OPEN_MAX)
 # endif
 // for AID_* constatns
-#include <private/android_filesystem_config.h>
+#include <cutils/android_filesystem_config.h>
 
 // getdtablesize() is removed from bionic/libc in LPDK*/
 // use POSIX alternative available. Otherwise fail

--- a/src/thermald.h
+++ b/src/thermald.h
@@ -44,7 +44,7 @@
 #undef LOG_TAG
 #define LOG_TAG "THERMALD"
 #include <utils/Log.h>
-#include <cutils/log.h>
+#include <log/log.h>
 #include <cutils/properties.h>
 
 #define thd_log_fatal	ALOGE


### PR DESCRIPTION
As per google's VNDK rules, vendor executables are supposed to link to an
allowed set of libraries (static and shared) and are supposed to use only
allower headers in the vendor code.

Following are the changes:
1. libicuuc no longer shall be linked in vendor application code.
2. Use log/log.h instead of cutils/log.h
3. Use cutils/android_filesystem_config.h instead of
   private/android_filesystem_config.h.

VNDK reference: https://source.android.com/devices/architecture/vndk

Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>