### PR TITLE
Modified the makefile to include libicuuc library for VNDK disabled builds

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -51,7 +51,11 @@ LOCAL_CFLAGS := \
 		-Werror
 
 LOCAL_STATIC_LIBRARIES := libxml2
+ifeq ($(BOARD_VNDK_VERSION),current)
 LOCAL_SHARED_LIBRARIES := liblog libcutils libdl libc++ libutils
+else
+LOCAL_SHARED_LIBRARIES := liblog libcutils libdl libc++ libicuuc libutils
+endif
 LOCAL_PRELINK_MODULE := false
 LOCAL_MODULE := thermal-daemon
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
For those builds with VNDK disabled, the libicuuc removal would break
the compilation. Hence, adding the library for builds in which VNDK
is disabled.

Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>