### PR TITLE
Make sure INT32_MAX is visible.

### DIFF
--- a/src/thd_trip_point.h
+++ b/src/thd_trip_point.h
@@ -29,6 +29,10 @@
 #include "thd_sys_fs.h"
 #include "thd_preference.h"
 #include "thd_cdev.h"
+
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+
 #include <time.h>
 #include <vector>
 #include <algorithm>    // std::sort


### PR DESCRIPTION
On Slackware, INT32_MAX is not visible. Setting `__STDC_LIMIT_MACROS` then including `stdint.h` will resolve it.