### PR TITLE
thd_parse: Fixing the klocwork issue reported

### DIFF
--- a/src/thd_parse.cpp
+++ b/src/thd_parse.cpp
@@ -338,6 +338,7 @@ int cthd_parse::parse_new_cooling_dev(xmlNode * a_node, xmlDoc *doc,
 	cdev->status = 0;
 	cdev->pid_enable = false;
 	cdev->unit_val = ABSOULUTE_VALUE;
+	cdev->debounce_interval = 0;
 	for (cur_node = a_node; cur_node; cur_node = cur_node->next) {
 		if (cur_node->type == XML_ELEMENT_NODE) {
 			DEBUG_PARSER_PRINT("node type: Element, name: %s value: %s\n", cur_node->name, xmlNodeListGetString(doc, cur_node->xmlChildrenNode, 1));


### PR DESCRIPTION
Change initializes the cooling device variable debounce_interval
to 0. The cdev variable used is declared in the stack.
debounce_interval was not initialized to a default value.

Initialize debounce_interval to 0 so that the variable is not
used uninitialized.

Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>