### PR TITLE
Log reduction for user builds

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -43,12 +43,17 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += external/libxml2/include
 
 LOCAL_PROPRIETARY_MODULE := true
+
 LOCAL_CFLAGS := \
-		-DTDRUNDIR='"/data/vendor/thermal-daemon"'\
-		-DTDCONFDIR='"/system/vendor/etc/thermal-daemon"'\
-		-Wno-unused-parameter\
-		-Wall\
-		-Werror
+		-DTDRUNDIR='"/data/vendor/thermal-daemon"' \
+		-DTDCONFDIR='"/system/vendor/etc/thermal-daemon"' \
+		-Wno-unused-parameter \
+		-Wall \
+		-Werror \
+
+ifneq (,$(filter userdebug eng, $(TARGET_BUILD_VARIANT)))
+  LOCAL_CFLAGS += -DLOG_DEBUG_INFO=1
+endif
 
 LOCAL_STATIC_LIBRARIES := libxml2
 ifeq ($(BOARD_VNDK_VERSION),current)

--- a/src/thd_trt_art_reader.cpp
+++ b/src/thd_trt_art_reader.cpp
@@ -477,6 +477,7 @@ void cthd_acpi_rel::create_platform_conf() {
 	conf_file << prefix.c_str() << "</ProductName>" << "\n";
 }
 
+#if LOG_DEBUG_INFO == 1
 void cthd_acpi_rel::dump_trt() {
 
 	union trt_object *trt = (union trt_object *) trt_data;
@@ -506,6 +507,13 @@ void cthd_acpi_rel::dump_art() {
 		PRINT_DEBUG("ART %d: WT %llu:\n", i, art[i].acpi_art_entry.weight);
 	}
 }
+#else
+void cthd_acpi_rel::dump_trt() {
+}
+
+void cthd_acpi_rel::dump_art() {
+}
+#endif
 
 void cthd_acpi_rel::create_platform_pref(int perf) {
 	if (perf)

--- a/src/thermald.h
+++ b/src/thermald.h
@@ -50,12 +50,20 @@
 #define thd_log_fatal	ALOGE
 #define thd_log_error	ALOGE
 #define thd_log_warn	ALOGW
+#if LOG_DEBUG_INFO == 1
 #define thd_log_info	ALOGI
 #define thd_log_debug 	ALOGD
+#else
+#define thd_log_info(...)
+#define thd_log_debug(...)
+#endif
 
 #else
 
 #include "config.h"
+
+// Keeping the logging flag enabled for non-android cases
+#define LOG_DEBUG_INFO	1
 
 #define LOCKF_SUPPORT
 #ifdef GLIB_SUPPORT


### PR DESCRIPTION
For user builds, info and debug logs are not expected to be present.
Most thermal daemon logs are info or debug level, and surface in eng,
user and userdebug build variants. This violates the SDL requirement
which prohibits debug and info logs in user builds. So, adding a
conditional compilation define for user build to avoid debug and info
logs from thermal daemon.

Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>