### PR TITLE
thd_parse: fix memory leak when xmlDocGetRootElement fails

### DIFF
--- a/src/thd_parse.cpp
+++ b/src/thd_parse.cpp
@@ -103,6 +103,7 @@ int cthd_parse::parser_init(std::string config_file) {
 
 	if (root_element == NULL) {
 		thd_log_warn("error: could not get root element \n");
+		xmlFreeDoc(doc);
 		return THD_ERROR;
 	}
 


### PR DESCRIPTION
Currently when parse_init calls xmlDocGetRootElement and this fails
the allocation of doc is not freed leading to a memory leak. Fix
this by free'ing doc on this specific error exit path.

Signed-off-by: Colin Ian King <colin.king@canonical.com>