### PR TITLE
thermal-daemon: Fix klocwork critical issues

### DIFF
--- a/src/thd_rapl_power_meter.cpp
+++ b/src/thd_rapl_power_meter.cpp
@@ -43,6 +43,7 @@ cthd_rapl_power_meter::cthd_rapl_power_meter(unsigned int mask) :
 		rapl_present(true), rapl_sysfs("/sys/class/powercap/intel-rapl/"), domain_list(
 				0), last_time(0), poll_thread(0), measure_mask(mask), enable_measurement(
 				false) {
+	thd_attr = pthread_attr_t();
 
 	if (rapl_sysfs.exists()) {
 		thd_log_debug("RAPL sysfs present \n");


### PR DESCRIPTION
Klocwork issue's message:
'this->thd_attr.flags' might not be initialized
in this constructor.
'this->thd_attr.stack_base' might not be initialized
in this constructor.
'this->thd_attr.stack_size' might not be initialized
in this constructor.
'this->thd_attr.guard_size' might not be initialized
in this constructor.
'this->thd_attr.sched_policy' might not be initialized
in this constructor.
'this->thd_attr.sched_priority' might not be initialized
in this constructor.
Solution:
Initialize 'this->thd_attr' to avoid this issue.
Issues:
#93963, #93964, #93965, #93966, #93967, #93968

Change-Id: I895be238b88e26fa44b5f24b123d781e2616b26f
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-81220
Signed-off-by: Sun Xinx <xinx.sun@intel.com>
Reviewed-on: https://android.intel.com:443/671272