### PR TITLE
Use correct format specifier for size_t

### DIFF
--- a/src/thd_zone.cpp
+++ b/src/thd_zone.cpp
@@ -319,7 +319,7 @@ void cthd_zone::add_trip(cthd_trip_point &trip) {
 void cthd_zone::update_highest_trip_temp(cthd_trip_point &trip)
 {
 	if (trip_points.size()) {
-		thd_log_info("trip_points.size():%lu\n", trip_points.size());
+		thd_log_info("trip_points.size():%zu\n", trip_points.size());
 		for (unsigned int j = trip_points.size() - 1;; --j) {
 			if (trip_points[j].get_trip_type() == trip.get_trip_type()) {
 				thd_log_info("updating existing trip temp \n");


### PR DESCRIPTION
%zu instead of %lu, otherwise on 32 bit:

| In file included from ../git/src/thd_common.h:27,
|                  from ../git/src/thd_zone.h:30,
|                  from ../git/src/thd_zone.cpp:34:
| ../git/src/thd_zone.cpp: In member function 'void cthd_zone::update_highest_trip_temp(cthd_trip_point&)':
| ../git/src/thd_zone.cpp:322:16: error: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'std::vector<cthd_trip_point>::size_type' {aka 'unsigned int'} [-Werror=format=]
|   322 |   thd_log_info("trip_points.size():%lu\n", trip_points.size());
|       |                ^~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~
|       |                                                            |
|       |                                                            std::vector<cthd_trip_point>::size_type {aka unsigned int}
| ../git/src/thermald.h:82:57: note: in definition of macro 'thd_log_info'
|    82 | #define thd_log_info(...) g_log(NULL, G_LOG_LEVEL_INFO, __VA_ARGS__)
|       |                                                         ^~~~~~~~~~~
| ../git/src/thd_zone.cpp:322:38: note: format string is defined here
|   322 |   thd_log_info("trip_points.size():%lu\n", trip_points.size());
|       |                                    ~~^
|       |                                      |
|       |                                      long unsigned int
|       |                                    %u

Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>