### PR TITLE
[Android][ThermalD] : Limiting thermal daemon logs

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -51,7 +51,7 @@ LOCAL_CFLAGS := \
 		-Wall \
 		-Werror \
 
-ifneq (,$(filter userdebug eng, $(TARGET_BUILD_VARIANT)))
+ifneq (,$(filter eng, $(TARGET_BUILD_VARIANT)))
   LOCAL_CFLAGS += -DLOG_DEBUG_INFO=1
 endif
 


### PR DESCRIPTION
	- Issue : As per feedback, it is observed that thermal daemon
		  is generating huge logs in android userdebug build.

        - Fix : Allowing only Error, Warning and Fatal logs in user
                and userdebug build for android OS.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-84501
Signed-off-by: ashish18590 <ashish18590@gmail.com>