### PR TITLE
[👌 IMPROVE] Check for flag support - specifically in support of clang

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,24 +6,13 @@ ACLOCAL_AMFLAGS =
 
 # Global C Flags
 AM_CFLAGS = ${DBUS_CFLAGS}
-AM_CXXFLAGS = ${DBUS_CFLAGS}\
-		$(XML_CFLAGS) \
-		-DTDRUNDIR=\"$(tdrundir)\" \
-		-DTDCONFDIR=\"$(tdconfdir)\" \
-		-I src \
-		-Wreorder \
-		-Wsign-compare \
-		-Wreturn-type \
-		-Wunused-but-set-variable\
-		-Wformat\
-		-Wall\
-		-Wclobbered\
-		-Wempty-body\
-		-Wignored-qualifiers\
-		-Wmissing-field-initializers\
-		-Wtype-limits\
-		-Wuninitialized\
-		-Werror
+AM_CXXFLAGS = \
+	${DBUS_CFLAGS} \
+	$(XML_CFLAGS) \
+	-DTDRUNDIR=\"$(tdrundir)\" \
+	-DTDCONFDIR=\"$(tdconfdir)\" \
+	$(CXXFLAGS) \
+	-I src
 
 EXTRA_DIST=Makefile.glib \
 	thermald.pc.in
@@ -39,54 +28,54 @@ thermald_CPPFLAGS = \
 
 thermald_includedir = @top_srcdir@
 thermald_LDADD = \
-        $(DBUS_LIBS) \
-        $(GLIB_LIBS) \
-        $(LIBNL_LIBS) \
-        $(LIBM) \
-        $(LIBDL) \
-		$(XML_LIBS)
+	$(DBUS_LIBS) \
+	$(GLIB_LIBS) \
+	$(LIBNL_LIBS) \
+	$(LIBM) \
+	$(LIBDL) \
+	$(XML_LIBS)
 
 BUILT_SOURCES = \
 	thd_dbus_interface.h
 
 thermald_SOURCES = \
-		src/main.cpp \
-		src/thd_dbus_interface.cpp \
-		src/thd_engine.cpp \
-		src/thd_cdev.cpp \
-		src/thd_cdev_therm_sys_fs.cpp \
-		src/thd_engine_default.cpp \
-		src/thd_sys_fs.cpp \
-		src/thd_trip_point.cpp \
-		src/thd_zone.cpp \
-		src/thd_zone_cpu.cpp \
-		src/thd_zone_therm_sys_fs.cpp \
-		src/thd_zone_dynamic.cpp \
-		src/thd_preference.cpp \
-		src/thd_parse.cpp \
-		src/thd_sensor.cpp \
-		src/thd_sensor_virtual.cpp \
-		src/thd_kobj_uevent.cpp \
-		src/thd_cdev_order_parser.cpp \
-		src/thd_cdev_gen_sysfs.cpp \
-		src/thd_pid.cpp \
-		src/thd_zone_generic.cpp \
-		src/thd_cdev_cpufreq.cpp \
-		src/thd_cdev_rapl.cpp \
-		src/thd_cdev_intel_pstate_driver.cpp \
-		src/thd_rapl_power_meter.cpp \
-		src/thd_trt_art_reader.cpp \
-		src/thd_cdev_rapl_dram.cpp \
-		src/thd_cpu_default_binding.cpp \
-		src/thd_cdev_backlight.cpp \
-		src/thd_cdev_modem.cpp \
-		src/thd_int3400.cpp \
-		src/thd_cdev_kbl_amdgpu.cpp \
-		src/thd_sensor_kbl_amdgpu_power.cpp \
-		src/thd_sensor_kbl_amdgpu_thermal.cpp \
-		src/thd_zone_kbl_g_mcp.cpp \
-		src/thd_sensor_kbl_g_mcp.cpp \
-		src/thd_zone_kbl_amdgpu.cpp
+	src/main.cpp \
+	src/thd_dbus_interface.cpp \
+	src/thd_engine.cpp \
+	src/thd_cdev.cpp \
+	src/thd_cdev_therm_sys_fs.cpp \
+	src/thd_engine_default.cpp \
+	src/thd_sys_fs.cpp \
+	src/thd_trip_point.cpp \
+	src/thd_zone.cpp \
+	src/thd_zone_cpu.cpp \
+	src/thd_zone_therm_sys_fs.cpp \
+	src/thd_zone_dynamic.cpp \
+	src/thd_preference.cpp \
+	src/thd_parse.cpp \
+	src/thd_sensor.cpp \
+	src/thd_sensor_virtual.cpp \
+	src/thd_kobj_uevent.cpp \
+	src/thd_cdev_order_parser.cpp \
+	src/thd_cdev_gen_sysfs.cpp \
+	src/thd_pid.cpp \
+	src/thd_zone_generic.cpp \
+	src/thd_cdev_cpufreq.cpp \
+	src/thd_cdev_rapl.cpp \
+	src/thd_cdev_intel_pstate_driver.cpp \
+	src/thd_rapl_power_meter.cpp \
+	src/thd_trt_art_reader.cpp \
+	src/thd_cdev_rapl_dram.cpp \
+	src/thd_cpu_default_binding.cpp \
+	src/thd_cdev_backlight.cpp \
+	src/thd_cdev_modem.cpp \
+	src/thd_int3400.cpp \
+	src/thd_cdev_kbl_amdgpu.cpp \
+	src/thd_sensor_kbl_amdgpu_power.cpp \
+	src/thd_sensor_kbl_amdgpu_thermal.cpp \
+	src/thd_zone_kbl_g_mcp.cpp \
+	src/thd_sensor_kbl_g_mcp.cpp \
+	src/thd_zone_kbl_amdgpu.cpp
 
 man5_MANS = man/thermal-conf.xml.5
 man8_MANS = man/thermald.8

--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,27 @@ AC_C_CONST
 AC_C_INLINE
 AC_TYPE_SIZE_T
 
+# Check for flag support.
+for flag in \
+    -Wall \
+    -Wclobbered \
+    -Wempty-body \
+    -Werror \
+    -Wformat \
+    -Wignored-qualifiers \
+    -Wmissing-field-initializers \
+    -Wreorder \
+    -Wreturn-type \
+    -Wsign-compare \
+    -Wtype-limits \
+    -Wuninitialized \
+    -Wunused-but-set-variable \
+; do
+    AX_CHECK_COMPILE_FLAG([-Werror ${flag}],
+                          [CXXFLAGS="$CXXFLAGS ${flag}"])
+done
+
 AC_CONFIG_FILES([Makefile
-data/Makefile])
+                 data/Makefile])
 
 AC_OUTPUT


### PR DESCRIPTION
Fixes #206.

Had to include `-Werror` in the check because otherwise clang only warns about the unsupported flag and doesn't fail the check as it should have.
```
    AX_CHECK_COMPILE_FLAG([-Werror ${flag}],
```

This is the output from my `./configure`. It excludes exactly the flags that were problematic.
```
checking whether C compiler accepts -Werror -Wall... yes
checking whether C compiler accepts -Werror -Wclobbered... no
checking whether C compiler accepts -Werror -Wempty-body... yes
checking whether C compiler accepts -Werror -Werror... yes
checking whether C compiler accepts -Werror -Wformat... yes
checking whether C compiler accepts -Werror -Wignored-qualifiers... yes
checking whether C compiler accepts -Werror -Wmissing-field-initializers... yes
checking whether C compiler accepts -Werror -Wreorder... yes
checking whether C compiler accepts -Werror -Wreturn-type... yes
checking whether C compiler accepts -Werror -Wsign-compare... yes
checking whether C compiler accepts -Werror -Wtype-limits... yes
checking whether C compiler accepts -Werror -Wuninitialized... yes
checking whether C compiler accepts -Werror -Wunused-but-set-variable... no
```

Would you please also accept the minor whitespace consistency changes that I included? It would please my OCD, I have no other argument.

