### PR TITLE
Check if AX_CHECK_COMPILE_FLAG is present.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,7 @@ AC_C_CONST
 AC_C_INLINE
 AC_TYPE_SIZE_T
 
+m4_ifdef([AX_CHECK_COMPILE_FLAG], [
 # Check for flag support.
 for flag in \
     -Wall \
@@ -97,6 +98,7 @@ for flag in \
     AX_CHECK_COMPILE_FLAG([-Werror ${flag}],
                           [CXXFLAGS="$CXXFLAGS ${flag}"])
 done
+], [AC_MSG_ERROR([AX_CHECK_COMPILE_FLAG not found, you'll need to install autoconf-archive])])
 
 AC_CONFIG_FILES([Makefile
                  data/Makefile])


### PR DESCRIPTION
AX_CHECK_COMPILE_FLAG is usually part of separate autoconf package,
called autoconf-archive, and on some distributions is not installed by
default.

When this macro is not present but user generates configure script,
it will complain with not so obvious message.

This commit fixes this by emitting clear message what is missing, so
user knows what to do next.