### PR TITLE
thd_trip_point: fix 32-bit build error with musl v1.2.0

### DIFF
--- a/src/thd_trip_point.cpp
+++ b/src/thd_trip_point.cpp
@@ -242,15 +242,9 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
 				time_t tm;
 				time(&tm);
 				if ((tm - cdevs[i].last_op_time) < cdevs[i].sampling_priod) {
-#if defined __x86_64__ && defined __ILP32__
-					thd_log_info("Too early to act zone:%d index %d tm %lld\n",
+					thd_log_info("Too early to act zone:%d index %d tm %jd\n",
 							zone_id, cdev->thd_cdev_get_index(),
-							tm - cdevs[i].last_op_time);
-#else
-					thd_log_info("Too early to act zone:%d index %d tm %ld\n",
-							zone_id, cdev->thd_cdev_get_index(),
-							tm - cdevs[i].last_op_time);
-#endif
+							(intmax_t)tm - cdevs[i].last_op_time);
 					break;
 				}
 				cdevs[i].last_op_time = tm;


### PR DESCRIPTION
Error log:
 ../git/src/thd_trip_point.cpp: In member function 'bool cthd_trip_point::thd_trip_point_check(int, unsigned int, int, bool*)':
| ../git/src/thd_trip_point.cpp:250:19: error: format '%ld' expects argument of type 'long int', but argument 6 has type 'time_t' {aka 'long long int'} [-Werror=format=]
|   250 |      thd_log_info("Too early to act zone:%d index %d tm %ld\n",

musl 1.2.0 have new feature:
time_t is now 64-bit on all archs (not just 64-bit archs)

Commit id:
https://git.musl-libc.org/cgit/musl/commit/?id=38143339646a4ccce8afe298c34467767c899f51

Release note link for musl 1.2.0:
https://git.musl-libc.org/cgit/musl/diff/

use %jd and typecast with intmax_t which is maximum width integer type

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>