### PR TITLE
Fix a couple of spelling mistakes and remove spaces before \n char

### DIFF
--- a/src/thd_engine.cpp
+++ b/src/thd_engine.cpp
@@ -257,13 +257,13 @@ int cthd_engine::thd_engine_start(bool ignore_cpuid_check) {
 				continue;
 			if (!zone->check_sensor_async_status()) {
 				thd_log_warn(
-						"Polling will be enabled as some sensors are not capable to notify asynchnously \n");
+						"Polling will be enabled as some sensors are not capable to notify asynchronously\n");
 				poll_timeout_msec = def_poll_interval;
 				break;
 			}
 		}
 		if (i == zones.size()) {
-			thd_log_info("Proceed without polling mode! \n");
+			thd_log_info("Proceed without polling mode!\n");
 		}
 
 		uevent_fd = poll_fd_cnt;

--- a/tools/thermal_monitor/qcustomplot/qcustomplot.cpp
+++ b/tools/thermal_monitor/qcustomplot/qcustomplot.cpp
@@ -16245,7 +16245,7 @@ void QCPSelectionDecoratorBracket::drawBracket(QCPPainter *painter, int directio
     }
     default:
     {
-      qDebug() << Q_FUNC_INFO << "unknown/custom bracket style can't be handeld by default implementation:" << static_cast<int>(mBracketStyle);
+      qDebug() << Q_FUNC_INFO << "unknown/custom bracket style can't be handled by default implementation:" << static_cast<int>(mBracketStyle);
       break;
     }
   }


### PR DESCRIPTION
There are a couple of spelling mistakes, fix these. Also remove
trailing spaces that occur before \n newline.

Signed-off-by: Colin Ian King <colin.king@canonical.com>