### PR TITLE
data: Add ConditionVirtualization=no to systemd service

### DIFF
--- a/data/thermald.service.in
+++ b/data/thermald.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Thermal Daemon Service
+ConditionVirtualization=no
 
 [Service]
 Type=dbus


### PR DESCRIPTION
It is not useful to run thermald on a virtualized system, and doing so
will simply result in log output without any real benefit. Add the
appropriate option to not start in a virtualized environment.

See #237