### PR TITLE
data: Disable thermald on Lenovo laptops with firmware power management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ thd_dbus_interface.h
 .project
 *thermald.service
 .dirstamp
+*90-thermald.rules

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ ABOUT-NLS
 *.pc
 cscope.*out
 thermald
+thermald-udev-helper
 thd_dbus_interface.h
 .cproject
 .project

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,3 +84,10 @@ thd_dbus_interface.h: $(top_srcdir)/src/thd_dbus_interface.xml
 	$(AM_V_GEN) dbus-binding-tool --prefix=thd_dbus_interface --mode=glib-server --output=$@ $<
 
 CLEANFILES = $(BUILT_SOURCES)
+
+if HAVE_SYSTEMD
+libexec_PROGRAMS = thermald-udev-helper
+thermald_udev_helper_CFLAGS=-I@top_srcdir@/src
+thermald_udev_helper_SOURCES = \
+	src/udev-helper.c
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -31,10 +31,16 @@ PKG_PROG_PKG_CONFIG
 AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
         [], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+AC_ARG_WITH([udevdir],
+        AS_HELP_STRING([--with-udevdir=DIR], [Directory for udev]),
+        [], [with_udevdir=$($PKG_CONFIG --variable=udevdir udev)])
 if test "x$with_systemdsystemunitdir" != xno; then
         AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
 fi
-AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir" -a "x$with_systemdsystemunitdir" != xno ])
+if test "x$with_udevdir" != xno; then
+        AC_SUBST([udevdir], [$with_udevdir])
+fi
+AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir" -a "x$with_systemdsystemunitdir" != xno -a -n "$with_udevdir" -a "x$with_udevdir" != xno ])
 
 # print configuration
 echo
@@ -42,6 +48,7 @@ echo "System paths:"
 echo "  prefix: $prefix"
 echo "  exec_prefix: $exec_prefix"
 echo "  systemdunitdir: $with_systemdsystemunitdir"
+echo "  udevdir: $with_udevdir"
 echo "  tdbinary: $tdbinary"
 echo "  tdconfdir: $tdconfdir"
 echo "  tdrundir: $tdrundir"

--- a/data/90-thermald.rules.in
+++ b/data/90-thermald.rules.in
@@ -1,0 +1,17 @@
+# thermald udev rules
+#
+# SPDX-License-Identifier: GPL-2.1+
+#
+# Copyright © 2020 Red Hat, Inc
+#
+# Authors:
+#       Benjamin Berg <bberg@redhat.com>
+#
+
+ACTION=="remove", GOTO="thermald_end"
+
+# Assume that having lap-mode exported by thinkpad_acpi
+# implies the device has in-firmware thermal management.
+DEVPATH=="/devices/platform/thinkpad_acpi", ATTR{dytc_lapmode}=="*", RUN+="@libexecdir@/thermald-udev-helper --firmware-managed"
+
+LABEL="thermald_end"

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,5 +1,12 @@
 include $(GLIB_MAKEFILE)
 
+edit = sed \
+	-e 's|@bindir[@]|$(bindir)|g' \
+	-e 's|@sbindir[@]|$(sbindir)|g' \
+	-e 's|@libexecdir[@]|$(libexecdir)|g' \
+	-e 's|@sysconfdir[@]|$(sysconfdir)|g' \
+	-e 's|@localstatedir[@]|$(localstatedir)|g'
+
 if HAVE_SYSTEMD
 systemdsystemunit_DATA = \
 	thermald.service
@@ -13,13 +20,13 @@ service_DATA = $(service_in_files:.service.in=.service)
 
 $(service_DATA): $(service_in_files) Makefile
 	@$(edit) $< >$@
-endif
 
-edit = sed \
-	-e 's|@bindir[@]|$(bindir)|g' \
-	-e 's|@sbindir[@]|$(sbindir)|g' \
-	-e 's|@sysconfdir[@]|$(sysconfdir)|g' \
-	-e 's|@localstatedir[@]|$(localstatedir)|g'
+udevrulesdir = $(udevdir)/rules.d
+udevrules_in_files = 90-thermald.rules.in
+udevrules_DATA = $(udevrules_in_files:.rules.in=.rules)
+$(udevrules_DATA): $(udevrules_in_files) Makefile
+	@$(edit) $< >$@
+endif
 
 dbusservicedir = $(DBUS_SYS_DIR)
 dbusservice_DATA = org.freedesktop.thermald.conf

--- a/data/thermald.service.in
+++ b/data/thermald.service.in
@@ -2,6 +2,12 @@
 Description=Thermal Daemon Service
 ConditionVirtualization=no
 
+# A udev rule may create this file to disable thermald on certain hardware
+ConditionPathExists=!/run/thermald/firmware-managed
+
+Wants=systemd-udev-trigger.service systemd-udev-settle.service
+After=systemd-udev-trigger.service systemd-udev-settle.service
+
 [Service]
 Type=dbus
 SuccessExitStatus=1

--- a/src/udev-helper.c
+++ b/src/udev-helper.c
@@ -1,0 +1,59 @@
+/*
+ * udev-helper.cpp: Simple utility to use from udev rules
+ *
+ * Copyright (C) 2020 Red Hat Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version
+ * 2 or later as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ *
+ * Author Name <bberg@redhat.com>
+ *
+ * This is a utility to use together with udev rules.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+int main(int argc, char **argv) {
+	/* Currently must be run using the --firmware-managed option,
+	 * so this is a bit lazy and doesn't do proper argument parsing
+	 * for now. */
+	int fd;
+
+	if (argc != 2 || strcmp(argv[1], "--firmware-managed") != 0) {
+		fprintf(stderr, "Must be run with --firmware-managed as the sole argument");
+		return 1;
+	}
+
+	/* Flag by creating the file /run/thermald/firmware-managed */
+	if (mkdir("/run/thermald", 0755) < 0) {
+		if (errno != EEXIST) {
+			fprintf(stderr, "Failed to create directory /run/thermald: %m\n");
+			return 1;
+		}
+	}
+
+	fd = creat("/run/thermald/firmware-managed", 0644);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to create file /run/thermald/firmware-managed: %m\n");
+	}
+
+	close(fd);
+}


### PR DESCRIPTION
More recent Lenovo ThinkPad machines have in-firmware power management.
This will generally give better results on these machines than using
thermald does, and we also do not want thermald and the firmware
fighting about the exact settings.

Simply disable thermald if the corresponding sysfs entry is found.

See https://patchwork.kernel.org/patch/11640537/ for the patch adding
this entry.

----

I do believe that this is the correct thing to do and adding it to the systemd unit is a straight foward (but I guess not optimal) solution. Probably not a good long-term solution, but likely reasonable in the short term.

CC: @mrhpearson