### PR TITLE
configure.ac: allow the user to disable -Werror

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,7 +95,6 @@ for flag in \
     -Wall \
     -Wclobbered \
     -Wempty-body \
-    -Werror \
     -Wformat \
     -Wignored-qualifiers \
     -Wmissing-field-initializers \
@@ -110,6 +109,9 @@ for flag in \
                           [CXXFLAGS="$CXXFLAGS ${flag}"])
 done
 ], [AC_MSG_ERROR([AX_CHECK_COMPILE_FLAG not found, you'll need to install autoconf-archive])])
+
+AC_ARG_ENABLE(werror, AS_HELP_STRING([--disable-werror], [Disable -Werror]))
+AS_IF([test "x$enable_werror" != "xno"], [CXXFLAGS="$CXXFLAGS -Werror"])
 
 AC_CONFIG_FILES([Makefile
                  docs/Makefile


### PR DESCRIPTION
This will fix the following build failure which is related to glib:

```
In file included from /home/buildroot/autobuild/run/instance-1/output-1/host/bin/../x86_64-buildroot-linux-gnu/sysroot/usr/include/glib-2.0/glib/gthread.h:32:0,
                 from /home/buildroot/autobuild/run/instance-1/output-1/host/bin/../x86_64-buildroot-linux-gnu/sysroot/usr/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /home/buildroot/autobuild/run/instance-1/output-1/host/bin/../x86_64-buildroot-linux-gnu/sysroot/usr/include/glib-2.0/glib.h:32,
                 from src/thermald.h:70,
                 from src/thd_dbus_interface.cpp:25:
src/thd_dbus_interface.cpp: In function 'GType pref_object_get_type()':
/home/buildroot/autobuild/run/instance-1/output-1/host/bin/../x86_64-buildroot-linux-gnu/sysroot/usr/include/glib-2.0/glib/gatomic.h:128:15: error: variable 'gapg_temp_atomic' set but not used [-Werror=unused-but-set-variable]
     gpointer *gapg_temp_atomic = (gpointer *)(atomic);                       \
               ^
```

Fixes:
 - http://autobuild.buildroot.org/results/80a126c225a9e9cbfdc30882c4ce00517d853d8b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>