### PR TITLE
adaptive fixes

### DIFF
--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -402,6 +402,11 @@ void cthd_engine_adaptive::dump_apct() {
 
 			if (condition_set[j].condition < ARRAY_SIZE(condition_names)) {
 				cond_name = condition_names[condition_set[j].condition];
+			} else if (condition_set[j].condition >= 0x1000 && condition_set[j].condition < 0x10000) {
+				std::stringstream msg;
+
+				msg << "Oem" << (condition_set[j].condition - 0x1000 + 6);
+				cond_name = msg.str();
 			} else {
 				std::stringstream msg;
 

--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -789,6 +789,8 @@ int cthd_engine_adaptive::parse_gddv(char *buf, int size, int *end_offset) {
 }
 
 int cthd_engine_adaptive::verify_condition(struct condition condition) {
+	const char *cond_name;
+
 	if (condition.condition >= Oem0 && condition.condition <= Oem5)
 		return 0;
 	if (condition.condition >= adaptive_condition(0x1000)
@@ -810,7 +812,8 @@ int cthd_engine_adaptive::verify_condition(struct condition condition) {
 	if (condition.condition == Platform_type)
 		return 0;
 
-	thd_log_error("Unsupported condition %d\n", condition.condition);
+	cond_name = condition_names[MIN(MAX(0, condition.condition), G_N_ELEMENTS(condition_names) - 1)];
+	thd_log_error("Unsupported condition %d (%s)\n", condition.condition, cond_name);
 	return THD_ERROR;
 }
 

--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -698,13 +698,6 @@ int cthd_engine_adaptive::parse_gddv(char *buf, int size) {
 		delete[] (val);
 	}
 
-	merge_appc();
-
-	dump_ppcc();
-	dump_psvt();
-	dump_apat();
-	dump_apct();
-
 	return 0;
 }
 
@@ -1398,6 +1391,13 @@ int cthd_engine_adaptive::thd_engine_start(bool ignore_cpuid_check) {
 			delete[] buf;
 			return THD_ERROR;
 		}
+
+		merge_appc();
+
+		dump_ppcc();
+		dump_psvt();
+		dump_apat();
+		dump_apct();
 	} catch (std::exception &e) {
 		thd_log_warn("%s\n", e.what());
 		delete [] buf;

--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -811,6 +811,8 @@ int cthd_engine_adaptive::verify_condition(struct condition condition) {
 		return 0;
 	if (condition.condition == Platform_type)
 		return 0;
+	if (condition.condition == Power_slider)
+		return 0;
 
 	cond_name = condition_names[MIN(MAX(0, condition.condition), G_N_ELEMENTS(condition_names) - 1)];
 	thd_log_error("Unsupported condition %d (%s)\n", condition.condition, cond_name);
@@ -988,6 +990,15 @@ int cthd_engine_adaptive::evaluate_platform_type_condition(
 	return compare_condition(condition, value);
 }
 
+int cthd_engine_adaptive::evaluate_power_slider_condition(
+		struct condition condition) {
+
+	// We don't have a power slider currently, just set it to 75 which
+	// equals "Better Performance" (using 100 would be more aggressive).
+
+	return compare_condition(condition, 75);
+}
+
 int cthd_engine_adaptive::evaluate_ac_condition(struct condition condition) {
 	int value = 0;
 	bool on_battery = up_client_get_on_battery(upower_client);
@@ -1031,6 +1042,10 @@ int cthd_engine_adaptive::evaluate_condition(struct condition condition) {
 
 	if (condition.condition == Platform_type) {
 		ret = evaluate_platform_type_condition(condition);
+	}
+
+	if (condition.condition == Power_slider) {
+		ret = evaluate_power_slider_condition(condition);
 	}
 
 	if (ret) {

--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -912,7 +912,7 @@ int cthd_engine_adaptive::evaluate_oem_condition(struct condition condition) {
 	int oem_condition = -1;
 
 	if (condition.condition >= Oem0 && condition.condition <= Oem5)
-		oem_condition = (int) condition.condition - 19;
+		oem_condition = (int) condition.condition - Oem0;
 	else if (condition.condition >= (adaptive_condition) 0x1000
 			&& condition.condition < (adaptive_condition) 0x10000)
 		oem_condition = (int) condition.condition - 0x1000 + 6;

--- a/src/thd_engine_adaptive.h
+++ b/src/thd_engine_adaptive.h
@@ -185,6 +185,7 @@ protected:
 	int evaluate_lid_condition(struct condition condition);
 	int evaluate_workload_condition(struct condition condition);
 	int evaluate_platform_type_condition(struct condition condition);
+	int evaluate_power_slider_condition(struct condition condition);
 	int evaluate_condition(struct condition condition);
 	int evaluate_condition_set(std::vector<struct condition> condition_set);
 	int evaluate_conditions();

--- a/src/thd_engine_adaptive.h
+++ b/src/thd_engine_adaptive.h
@@ -169,7 +169,8 @@ protected:
 	int parse_ppcc(char *name, char *ppcc, int len);
 	int parse_psvt(char *name, char *psvt, int len);
 	int handle_compressed_gddv(char *buf, int size);
-	int parse_gddv(char *buf, int size);
+	int parse_gddv_key(char *buf, int size, int *end_offset);
+	int parse_gddv(char *buf, int size, int *end_offset);
 	struct psvt* find_psvt(std::string name);
 	int install_passive(struct psv *psv);
 	void set_trip(std::string device, std::string argument);


### PR DESCRIPTION
I'll probably push more stuff, but should be acceptable in theory.

With these changes, I can fully unpack the DPTF data on the X1C8 (still useless obviously), without it thermald falls on its feet when it encounters the second data vault object in the compressed data.