### PR TITLE
Fixed gcc 5.x compilation and unrecognized types

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ AC_C_INLINE
 AC_TYPE_SIZE_T
 
 m4_ifdef([AX_CHECK_COMPILE_FLAG], [
-# Check for flag support.
+# Check for -Werror flag support.
 for flag in \
     -Wall \
     -Wclobbered \
@@ -108,6 +108,10 @@ for flag in \
     AX_CHECK_COMPILE_FLAG([-Werror ${flag}],
                           [CXXFLAGS="$CXXFLAGS ${flag}"])
 done
+
+# Check for c++0x support.
+AX_CHECK_COMPILE_FLAG([-std=c++0x],
+                      [CXXFLAGS="$CXXFLAGS -std=c++0x"])
 ], [AC_MSG_ERROR([AX_CHECK_COMPILE_FLAG not found, you'll need to install autoconf-archive])])
 
 AC_ARG_ENABLE(werror, AS_HELP_STRING([--disable-werror], [Disable -Werror]))

--- a/src/thd_adaptive_types.h
+++ b/src/thd_adaptive_types.h
@@ -1,6 +1,8 @@
 #ifndef THD_ADAPTIVE_TYPES_H_
 #define THD_ADAPTIVE_TYPES_H_
 
+#include <stdint.h>
+
 struct adaptive_target {
 	uint64_t target_id;
 	std::string name;

--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -25,6 +25,7 @@
 #include <arpa/inet.h>
 #include <dirent.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <lzma.h>
 #include <linux/input.h>
 #include <sys/types.h>


### PR DESCRIPTION
On Slackware, stdint.h and inittypes.h are not implicitly included,
so `uint64_t` and `PRIu64` will not be recognized. This is fixed by
explicitly including those headers.

Also, check for and enable C++0x support because current code is using it.