### PR TITLE
thd_engine_adapive: Change some struct field types

### DIFF
--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -846,7 +846,7 @@ int cthd_engine_adaptive::verify_condition(struct condition condition) {
 		return 0;
 
 	cond_name = condition_names[MIN(MAX(0, condition.condition), G_N_ELEMENTS(condition_names) - 1)];
-	thd_log_error("Unsupported condition %d (%s)\n", condition.condition, cond_name);
+	thd_log_error("Unsupported condition %" PRIu64 " (%s)\n", condition.condition, cond_name);
 	return THD_ERROR;
 }
 
@@ -880,11 +880,11 @@ int cthd_engine_adaptive::compare_condition(struct condition condition,
 						cond_name.c_str(), comp_str.c_str(), value);
 			} else {
 				thd_log_debug(
-						"compare condition [%s] comparison [%d] value [%d]\n",
+						"compare condition [%s] comparison [%" PRIu64 "] value [%d]\n",
 						cond_name.c_str(), condition.comparison, value);
 			}
 		} else {
-			thd_log_debug("compare condition %d value %d\n",
+			thd_log_debug("compare condition %" PRIu64 " value %d\n",
 					condition.comparison, value);
 		}
 	}
@@ -1046,7 +1046,7 @@ int cthd_engine_adaptive::evaluate_condition(struct condition condition) {
 	if (condition.condition == Default)
 		return THD_SUCCESS;
 
-	thd_log_debug("evaluate condition.condition %d\n", condition.condition);
+	thd_log_debug("evaluate condition.condition %" PRIu64 "\n", condition.condition);
 
 	if ((condition.condition >= Oem0 && condition.condition <= Oem5)
 			|| (condition.condition >= (adaptive_condition) 0x1000

--- a/src/thd_engine_adaptive.h
+++ b/src/thd_engine_adaptive.h
@@ -119,9 +119,9 @@ struct psv {
 };
 
 struct condition {
-	enum adaptive_condition condition;
+	uint64_t condition;
 	std::string device;
-	enum adaptive_comparison comparison;
+	uint64_t comparison;
 	int argument;
 	enum adaptive_operation operation;
 	enum adaptive_comparison time_comparison;


### PR DESCRIPTION
The condition and comparison fields of the condition struct are used
for arbitrary integer values, not just the ones in their respective enum
fields. Reflect this by using an integer type and not an enum type.

This fixes the build with clang.

Fixes #284

I see there are tests in `tests/`, but I did not run any of them since I am not sure how.
