### PR TITLE
Fix spelling mistakes found using codespell

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -130,7 +130,7 @@ Release 2.3
 - Merged changes from mjg59 for adaptive
 - Requires Linux kernel version 5.8 or later
 - By default tries --adaptive and fallback to old style
-- Atleast some level of success to use adaptive option on:
+- At least some level of success to use adaptive option on:
 (not expected to be on par with Windows DPTF)
 Dell XPS 13 9360
 Dell XPS 13 9370
@@ -304,7 +304,7 @@ Release 1.03
 - Added P state turbo on/off
 
 Release 1.02
-- Allow user to change the max temperarure via dbus message
+- Allow user to change the max temperature via dbus message
 - Allow user to change the cooling method order via an XML configuration
 - Upstart fixes
 - Valgrind and zero warnings on build
@@ -368,7 +368,7 @@ on slope and angular increments to dynamically adjust set point
 
 
 Version 0.2
-- Define XML interface to set configuration data. Refere to thermal-conf.xml. This allows to override buggy Bios thermal comfiguration and also allows to extend the capability.
+- Define XML interface to set configuration data. Refer to thermal-conf.xml. This allows to override buggy Bios thermal comfiguration and also allows to extend the capability.
 - Use platform DMI UUID to index into configuration data. If there is no UUID match, falls back to thermal sysfs
 - Terminate interface
 - Takes over control from kernel thermal processing
@@ -380,7 +380,7 @@ Version 0.1
 - Defines a C++ classes for zones, cooling devices, trip points, thermal engine
 - Methods can be overridden in a custom class to modify default behaviour
 - Read thermal zone and cooling devices, trip points etc,
-- Read temprature via netlink notification or via polling configurable via command line
+- Read temperature via netlink notification or via polling configurable via command line
 - Once a trip point is crossed, activate the associate cooling devices. Start with min tstate to max tstate for each cooling device.
 - Based on active or passive settings it decides the cooling devices
 

--- a/data/thermal-conf.xml
+++ b/data/thermal-conf.xml
@@ -98,7 +98,7 @@ use "man thermal-conf.xml" for details
 					<!-- max/passive/active
 						If a MAX type is specified, then
 						daemon will use PID control
-						to aggresively throttle to avoid
+						to aggressively throttle to avoid
 						reaching this temp.
 					 -->
 					<type>max</type>

--- a/man/thermald.8
+++ b/man/thermald.8
@@ -51,7 +51,7 @@ For manual configuration refer to the manual page of the thermal-conf.xml.
 In some newer platforms the auto creation of the config file is done by a companion tool "dptfxtract". This tool can be downloaded from
 "https://github.com/intel/dptfxtract". It is suggested as parts of the install process, run dptfxtract.
 
-There can be multiple configuration files. User can select a configuration file via -config-file option to overide the default selection. The default selection picks one of the file in the following order:
+There can be multiple configuration files. User can select a configuration file via -config-file option to override the default selection. The default selection picks one of the file in the following order:
 
 - /etc/thermald/thermal-conf.xml.auto
 

--- a/src/android_main.cpp
+++ b/src/android_main.cpp
@@ -231,7 +231,7 @@ int main(int argc, char *argv[]) {
 
 	is_privileged_user = (getuid() == 0) || (getuid() == AID_SYSTEM);
 	if (!is_privileged_user && !test_mode) {
-		thd_log_error("You do not have correct permissions to run thermal dameon!\n");
+		thd_log_error("You do not have correct permissions to run thermal daemon!\n");
 		exit(1);
 	}
 

--- a/src/thd_cdev_modem.cpp
+++ b/src/thd_cdev_modem.cpp
@@ -340,7 +340,7 @@ void cthd_cdev_modem::update_throttling_state() {
 	conn = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	if (dbus_error_is_set(&error)) {
-		thd_log_error("Error :%s", error.message);
+		thd_log_error("Error: %s", error.message);
 		dbus_error_free(&error);
 		return;
 	}
@@ -398,7 +398,7 @@ void cthd_cdev_modem::set_curr_state(int state, int arg) {
 	conn = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	if (dbus_error_is_set(&error)) {
-		thd_log_error("Erro : %s", error.message);
+		thd_log_error("Error : %s", error.message);
 		dbus_error_free(&error);
 		return;
 	}

--- a/src/thd_engine.h
+++ b/src/thd_engine.h
@@ -54,7 +54,7 @@ typedef enum {
 	FAST_POLL_DISABLE,
 } message_name_t;
 
-// This defines whether the thermal control is entirey done by
+// This defines whether the thermal control is entirely done by
 // this daemon or it just complements, what is done in kernel
 typedef enum {
 	COMPLEMENTRY, EXCLUSIVE,

--- a/src/thd_parse.cpp
+++ b/src/thd_parse.cpp
@@ -97,7 +97,7 @@ int cthd_parse::parser_init(std::string config_file) {
 		xml_config_file = config_file.c_str();
 	}
 
-	/* We have not tested existance yet in this case. */
+	/* We have not tested existence yet in this case. */
 	if (!auto_config) {
 		std::ifstream conf(xml_config_file);
 		if (!conf.is_open()) {

--- a/src/thd_zone.cpp
+++ b/src/thd_zone.cpp
@@ -1,5 +1,5 @@
 /*
- * thd_zone.cpp: thermal zone class implentation
+ * thd_zone.cpp: thermal zone class implementation
  *
  * Copyright (C) 2012 Intel Corporation. All rights reserved.
  *

--- a/test/test6.xml
+++ b/test/test6.xml
@@ -4,7 +4,7 @@ This test configuration tests how target state can be set. Here we also
 test if multiple target state for multiple trips to the same cooling
 device. Here two trips have target state the last trip doesn't have
 any target state and will go up to max. Make sure that system behaves
-any temperature chage"
+any temperature change"
 - 40 to 50 to 60
 - Directly to 60
 - Wild wings between 10 to 60C

--- a/test/test_cases.txt
+++ b/test/test_cases.txt
@@ -4,7 +4,7 @@ Setup
 - One window: while true; do cat /sys/class/powercap/intel-rapl/intel-rapl\:0/constraint_0_power_limit_uw;sleep 1; done
 - Other window: sudo turbostat --show PkgWatt
 
-1. Singe step
+1. Single step
 
 File Name: thermal_conf.xml.1
 
@@ -240,7 +240,7 @@ PkgWatt
 25000000
 
 
-1.2.2 Not upto min
+1.2.2 Not up to min
 The trip recovers before.
 
 25000000

--- a/tools/thermal_monitor/qcustomplot/changelog.txt
+++ b/tools/thermal_monitor/qcustomplot/changelog.txt
@@ -125,7 +125,7 @@ Other:
     - Fixed bug that allowed scatter-only graphs to be selected by clicking the non-existent line between scatters
     - Fixed crash when trying to select a scatter-only QCPGraph whose only points in the visible key range are at identical key coordinates and vertically off-screen, with adaptive sampling enabled
     - Fixed pdf export of QCPColorMap with enabled interpolation (didn't appear interpolated in pdf)
-    - Reduced QCPColorMap jitter of internal cell boundaries for small sized maps when viewed with high zoom, by applying oversampling factors dependant on map size
+    - Reduced QCPColorMap jitter of internal cell boundaries for small sized maps when viewed with high zoom, by applying oversampling factors dependent on map size
     - Fixed bug of QCPColorMap::fill() not causing the buffered internal image map to be updated, and thus the change didn't become visible immediately
     - Axis labels with size set in pixels (setPixelSize) instead of points now correctly calculate the exponent's font size if beautifully typeset powers are enabled
     - Fixed QCPColorMap appearing at the wrong position for logarithmic axes and color map spanning larger ranges
@@ -435,7 +435,7 @@ Other:
   - QCPAxis::setLabelColor and setTickLabelColor
   - QCustomPlot::setTitleColor
   - QCustomPlot now emits beforeReplot and afterReplot signals. Note that it is safe to make two customPlots mutually call eachothers replot functions
-    in one of these slots, it will not cause an infinite loop. (usefull for synchronizing axes ranges between two customPlots, because setRange alone doesn't replot)
+    in one of these slots, it will not cause an infinite loop. (useful for synchronizing axes ranges between two customPlots, because setRange alone doesn't replot)
   - If the Qt version is 4.7 or greater, the tick label strings in date-time-mode now support sub-second accuracy (e.g. with format like "hh:mm:ss.zzz").
 
   Bugfixes:

--- a/tools/thermal_monitor/qcustomplot/qcustomplot.cpp
+++ b/tools/thermal_monitor/qcustomplot/qcustomplot.cpp
@@ -1717,7 +1717,7 @@ void QCPLayerable::mousePressEvent(QMouseEvent *event, const QVariant &details)
 
   The current pixel position of the cursor on the QCustomPlot widget is accessible via \c
   event->pos(). The parameter \a startPos indicates the position where the initial \ref
-  mousePressEvent occured, that started the mouse interaction.
+  mousePressEvent occurred, that started the mouse interaction.
 
   The default implementation does nothing.
 
@@ -1735,7 +1735,7 @@ void QCPLayerable::mouseMoveEvent(QMouseEvent *event, const QPointF &startPos)
 
   The current pixel position of the cursor on the QCustomPlot widget is accessible via \c
   event->pos(). The parameter \a startPos indicates the position where the initial \ref
-  mousePressEvent occured, that started the mouse interaction.
+  mousePressEvent occurred, that started the mouse interaction.
 
   The default implementation does nothing.
 
@@ -3146,7 +3146,7 @@ void QCPMarginGroup::removeChild(QCP::MarginSide side, QCPLayoutElement *element
 /*! \fn QRect QCPLayoutElement::rect() const
   
   Returns the inner rect of this layout element. The inner rect is the outer rect (\ref
-  setOuterRect) shrinked by the margins (\ref setMargins, \ref setAutoMargins).
+  setOuterRect) shrunk by the margins (\ref setMargins, \ref setAutoMargins).
   
   In some cases, the area between outer and inner rect is left blank. In other cases the margin
   area is used to display peripheral graphics while the main content is in the inner rect. This is
@@ -3732,7 +3732,7 @@ void QCPLayout::updateLayout()
   \ref QCPLayerable::parentLayerable and the QObject parent to this layout.
   
   Further, if \a el didn't previously have a parent plot, calls \ref
-  QCPLayerable::initializeParentPlot on \a el to set the paret plot.
+  QCPLayerable::initializeParentPlot on \a el to set the parent plot.
   
   This method is used by subclass specific methods that add elements to the layout. Note that this
   method only changes properties in \a el. The removal from the old layout and the insertion into
@@ -3835,11 +3835,11 @@ QVector<int> QCPLayout::getSectionSizes(QVector<int> maxSizes, QVector<int> minS
   double freeSize = totalSize;
   
   int outerIterations = 0;
-  while (!unfinishedSections.isEmpty() && outerIterations < sectionCount*2) // the iteration check ist just a failsafe in case something really strange happens
+  while (!unfinishedSections.isEmpty() && outerIterations < sectionCount*2) // the iteration check is just a failsafe in case something really strange happens
   {
     ++outerIterations;
     int innerIterations = 0;
-    while (!unfinishedSections.isEmpty() && innerIterations < sectionCount*2) // the iteration check ist just a failsafe in case something really strange happens
+    while (!unfinishedSections.isEmpty() && innerIterations < sectionCount*2) // the iteration check is just a failsafe in case something really strange happens
     {
       ++innerIterations;
       // find section that hits its maximum next:
@@ -4242,7 +4242,7 @@ void QCPLayoutGrid::setWrap(int count)
 
   If you want to have all current elements arranged in the new order, set \a rearrange to true. The
   elements will be rearranged in a way that tries to preserve their linear index. However, empty
-  cells are skipped during build-up of the new cell order, which shifts the succeding element's
+  cells are skipped during build-up of the new cell order, which shifts the succeeding element's
   index. The rearranging is performed even if the specified \a order is already the current fill
   order. Thus this method can be used to re-wrap the current elements.
 
@@ -5437,7 +5437,7 @@ void QCPAxisTicker::generate(const QCPRange &range, const QLocale &locale, QChar
   // generate (major) ticks:
   double tickStep = getTickStep(range);
   ticks = createTickVector(tickStep, range);
-  trimTicks(range, ticks, true); // trim ticks to visible range plus one outer tick on each side (incase a subclass createTickVector creates more)
+  trimTicks(range, ticks, true); // trim ticks to visible range plus one outer tick on each side (in case a subclass createTickVector creates more)
   
   // generate sub ticks between major ticks:
   if (subTicks)
@@ -6392,7 +6392,7 @@ double QCPAxisTickerFixed::getTickStep(const QCPRange &range)
   
   This is useful for cases where the axis represents categories rather than numerical values.
   
-  If you are updating the ticks of this ticker regularly and in a dynamic fasion (e.g. dependent on
+  If you are updating the ticks of this ticker regularly and in a dynamic fashion (e.g. dependent on
   the axis range), it is a sign that you should probably create an own ticker by subclassing
   QCPAxisTicker, instead of using this one.
   
@@ -8417,7 +8417,7 @@ void QCPAxis::rescale(bool onlyVisiblePlottables)
   {
     if (!QCPRange::validRange(newRange)) // likely due to range being zero (plottable has only constant data in this axis dimension), shift current range to at least center the plottable
     {
-      double center = (newRange.lower+newRange.upper)*0.5; // upper and lower should be equal anyway, but just to make sure, incase validRange returned false for other reason
+      double center = (newRange.lower+newRange.upper)*0.5; // upper and lower should be equal anyway, but just to make sure, in case validRange returned false for other reason
       if (mScaleType == stLinear)
       {
         newRange.lower = center-mRange.size()/2.0;
@@ -10639,7 +10639,7 @@ void QCPAbstractPlottable::setSelectable(QCP::SelectionType selectable)
   taking the orientations of the axes associated with this plottable into account (e.g. whether key
   represents x or y).
 
-  \a key and \a value are transformed to the coodinates in pixels and are written to \a x and \a y.
+  \a key and \a value are transformed to the coordinates in pixels and are written to \a x and \a y.
 
   \see pixelsToCoords, QCPAxis::coordToPixel
 */
@@ -10681,7 +10681,7 @@ const QPointF QCPAbstractPlottable::coordsToPixels(double key, double value) con
   taking the orientations of the axes associated with this plottable into account (e.g. whether key
   represents x or y).
 
-  \a x and \a y are transformed to the plot coodinates and are written to \a key and \a value.
+  \a x and \a y are transformed to the plot coordinates and are written to \a key and \a value.
 
   \see coordsToPixels, QCPAxis::coordToPixel
 */
@@ -10752,7 +10752,7 @@ void QCPAbstractPlottable::rescaleKeyAxis(bool onlyEnlarge) const
       newRange.expand(keyAxis->range());
     if (!QCPRange::validRange(newRange)) // likely due to range being zero (plottable has only constant data in this axis dimension), shift current range to at least center the plottable
     {
-      double center = (newRange.lower+newRange.upper)*0.5; // upper and lower should be equal anyway, but just to make sure, incase validRange returned false for other reason
+      double center = (newRange.lower+newRange.upper)*0.5; // upper and lower should be equal anyway, but just to make sure, in case validRange returned false for other reason
       if (keyAxis->scaleType() == QCPAxis::stLinear)
       {
         newRange.lower = center-keyAxis->range().size()/2.0;
@@ -10795,7 +10795,7 @@ void QCPAbstractPlottable::rescaleValueAxis(bool onlyEnlarge, bool inKeyRange) c
       newRange.expand(valueAxis->range());
     if (!QCPRange::validRange(newRange)) // likely due to range being zero (plottable has only constant data in this axis dimension), shift current range to at least center the plottable
     {
-      double center = (newRange.lower+newRange.upper)*0.5; // upper and lower should be equal anyway, but just to make sure, incase validRange returned false for other reason
+      double center = (newRange.lower+newRange.upper)*0.5; // upper and lower should be equal anyway, but just to make sure, in case validRange returned false for other reason
       if (valueAxis->scaleType() == QCPAxis::stLinear)
       {
         newRange.lower = center-valueAxis->range().size()/2.0;
@@ -10861,7 +10861,7 @@ bool QCPAbstractPlottable::addToLegend()
 
 /*! \overload
 
-  Removes the plottable from the specifed \a legend. This means the \ref QCPPlottableLegendItem
+  Removes the plottable from the specified \a legend. This means the \ref QCPPlottableLegendItem
   that is associated with this plottable is removed.
 
   Returns true on success, i.e. if the legend exists and a legend item associated with this
@@ -12044,7 +12044,7 @@ void QCPAbstractItem::setSelected(bool selected)
   that name, returns 0.
   
   This function provides an alternative way to access item positions. Normally, you access
-  positions direcly by their member pointers (which typically have the same variable name as \a
+  positions directly by their member pointers (which typically have the same variable name as \a
   name).
   
   \see positions, anchor
@@ -12065,7 +12065,7 @@ QCPItemPosition *QCPAbstractItem::position(const QString &name) const
   that name, returns 0.
   
   This function provides an alternative way to access item anchors. Normally, you access
-  anchors direcly by their member pointers (which typically have the same variable name as \a
+  anchors directly by their member pointers (which typically have the same variable name as \a
   name).
   
   \see anchors, position
@@ -14140,7 +14140,7 @@ void QCustomPlot::replot(QCustomPlot::RefreshPriority refreshPriority)
     return;
   }
   
-  if (mReplotting) // incase signals loop back to replot slot
+  if (mReplotting) // in case signals loop back to replot slot
     return;
   mReplotting = true;
   mReplotQueued = false;
@@ -14482,7 +14482,7 @@ void QCustomPlot::resizeEvent(QResizeEvent *event)
   
  Event handler for when a double click occurs. Emits the \ref mouseDoubleClick signal, then
  determines the layerable under the cursor and forwards the event to it. Finally, emits the
- specialized signals when certain objecs are clicked (e.g. \ref plottableDoubleClick, \ref
+ specialized signals when certain objects are clicked (e.g. \ref plottableDoubleClick, \ref
  axisDoubleClick, etc.).
  
  \see mousePressEvent, mouseReleaseEvent
@@ -14738,7 +14738,7 @@ void QCustomPlot::updateLayout()
   the viewport with the provided \a painter. The scaled version is buffered in
   mScaledBackgroundPixmap to prevent expensive rescaling at every redraw. It is only updated, when
   the axis rect has changed in a way that requires a rescale of the background pixmap (this is
-  dependent on the \ref setBackgroundScaledMode), or when a differend axis background pixmap was
+  dependent on the \ref setBackgroundScaledMode), or when a different axis background pixmap was
   set.
   
   Note that this function does not draw a fill with the background brush
@@ -16253,7 +16253,7 @@ void QCPSelectionDecoratorBracket::drawBracket(QCPPainter *painter, int directio
 
 /*!
   Draws the bracket decoration on the data points at the begin and end of each selected data
-  segment given in \a seletion.
+  segment given in \a selection.
   
   It uses the method \ref drawBracket to actually draw the shapes.
   
@@ -16630,7 +16630,7 @@ QList<QCPAxis*> QCPAxisRect::axes() const
   new QCPAxis instance is created internally. QCustomPlot owns the returned axis, so if you want to
   remove an axis, use \ref removeAxis instead of deleting it manually.
 
-  You may inject QCPAxis instances (or sublasses of QCPAxis) by setting \a axis to an axis that was
+  You may inject QCPAxis instances (or subclasses of QCPAxis) by setting \a axis to an axis that was
   previously created outside QCustomPlot. It is important to note that QCustomPlot takes ownership
   of the axis, so you may not delete it afterwards. Further, the \a axis must have been created
   with this axis rect as parent and with the same axis type as specified in \a type. If this is not
@@ -17382,7 +17382,7 @@ void QCPAxisRect::setRangeZoomFactor(double factor)
   the axis rect with the provided \a painter. The scaled version is buffered in
   mScaledBackgroundPixmap to prevent expensive rescaling at every redraw. It is only updated, when
   the axis rect has changed in a way that requires a rescale of the background pixmap (this is
-  dependent on the \ref setBackgroundScaledMode), or when a differend axis background pixmap was
+  dependent on the \ref setBackgroundScaledMode), or when a different axis background pixmap was
   set.
   
   \see setBackground, setBackgroundScaled, setBackgroundScaledMode
@@ -18357,7 +18357,7 @@ bool QCPLegend::hasItemWithPlottable(const QCPAbstractPlottable *plottable) cons
   Adds \a item to the legend, if it's not present already. The element is arranged according to the
   current fill order (\ref setFillOrder) and wrapping (\ref setWrap).
 
-  Returns true on sucess, i.e. if the item wasn't in the list already and has been successfuly added.
+  Returns true on success, i.e. if the item wasn't in the list already and has been successfully added.
 
   The legend takes ownership of the item.
 
@@ -19351,7 +19351,7 @@ void QCPColorScale::rescaleDataRange(bool onlyVisibleMaps)
   {
     if (!QCPRange::validRange(newRange)) // likely due to range being zero (plottable has only constant data in this dimension), shift current range to at least center the data
     {
-      double center = (newRange.lower+newRange.upper)*0.5; // upper and lower should be equal anyway, but just to make sure, incase validRange returned false for other reason
+      double center = (newRange.lower+newRange.upper)*0.5; // upper and lower should be equal anyway, but just to make sure, in case validRange returned false for other reason
       if (mDataScaleType == QCPAxis::stLinear)
       {
         newRange.lower = center-mDataRange.size()/2.0;
@@ -22766,7 +22766,7 @@ double QCPCurve::pointDistance(const QPointF &pixelPoint, QCPCurveDataContainer:
   \section qcpbarsgroup-usage Usage
   
   To add a QCPBars plottable to the group, create a new group and then add the respective bars
-  intances:
+  instances:
   \snippet documentation/doc-code-snippets/mainwindow.cpp qcpbarsgroup-creation
   Alternatively to appending to the group like shown above, you can also set the group on the
   QCPBars plottable via \ref QCPBars::setBarsGroup.
@@ -25323,7 +25323,7 @@ void QCPColorMap::setGradient(const QCPColorGradient &gradient)
 
 /*!
   Sets whether the color map image shall use bicubic interpolation when displaying the color map
-  shrinked or expanded, and not at a 1:1 pixel-to-data scale.
+  shrunk or expanded, and not at a 1:1 pixel-to-data scale.
   
   \image html QCPColorMap-interpolate.png "A 10*10 color map, with interpolation and without interpolation enabled"
 */
@@ -29160,7 +29160,7 @@ QPen QCPItemPixmap::mainPen() const
   the coordinate axes of the graph and update its \a position to be on the graph's data. This means
   the key stays controllable via \ref setGraphKey, but the value will follow the graph data. If a
   QCPGraph is connected, note that setting the coordinates of the tracer item directly via \a
-  position will have no effect because they will be overriden in the next redraw (this is when the
+  position will have no effect because they will be overridden in the next redraw (this is when the
   coordinate update happens).
   
   If the specified key in \ref setGraphKey is outside the key bounds of the graph, the tracer will

--- a/tools/thermal_monitor/qcustomplot/qcustomplot.h
+++ b/tools/thermal_monitor/qcustomplot/qcustomplot.h
@@ -2417,7 +2417,7 @@ protected:
   // property members:
   bool mAutoSqueeze;
   
-  // non-property memebers:
+  // non-property members:
   QVector<DataType> mData;
   int mPreallocSize;
   int mPreallocIteration;
@@ -2772,7 +2772,7 @@ void QCPDataContainer<DataType>::remove(double sortKeyFrom, double sortKeyTo)
   
   Removes a single data point at \a sortKey. If the position is not known with absolute (binary)
   precision, consider using \ref remove(double sortKeyFrom, double sortKeyTo) with a small
-  fuzziness interval around the suspected position, depeding on the precision with which the
+  fuzziness interval around the suspected position, depending on the precision with which the
   (sort-)key is known.
   
   \see removeBefore, removeAfter, clear
@@ -4412,7 +4412,7 @@ public:
     there for an image of the presets.
   */
   enum GradientPreset { gpGrayscale  ///< Continuous lightness from black to white (suited for non-biased data representation)
-                        ,gpHot       ///< Continuous lightness from black over firey colors to white (suited for non-biased data representation)
+                        ,gpHot       ///< Continuous lightness from black over fiery colors to white (suited for non-biased data representation)
                         ,gpCold      ///< Continuous lightness from black over icey colors to white (suited for non-biased data representation)
                         ,gpNight     ///< Continuous lightness from black over weak blueish colors to white (suited for non-biased data representation)
                         ,gpCandy     ///< Blue over pink to white

--- a/tools/thermal_monitor/thermaldinterface.cpp
+++ b/tools/thermal_monitor/thermaldinterface.cpp
@@ -141,7 +141,7 @@ bool ThermaldInterface::initialize()
                 }
             }
         }
-        // Store the actual number of trips, as opposed to the theoritical maximum
+        // Store the actual number of trips, as opposed to the theoretical maximum
         zones[i].trip_count = zones[i].trips.count();
 
         // Store the first valid trip temp for the zone


### PR DESCRIPTION
There are a handful of spelling mistakes in comments and literal
strings found by codespell. Fix these.

Signed-off-by: Colin Ian King <colin.king@canonical.com>