### PR TITLE
fix: Wrong variable cdev_count is used to report the GetZoneCount error

### DIFF
--- a/tools/thermal_monitor/thermaldinterface.cpp
+++ b/tools/thermal_monitor/thermaldinterface.cpp
@@ -106,7 +106,7 @@ bool ThermaldInterface::initialize()
     if (z_count.isValid()) {
         zone_count = z_count;
     } else {
-        qCritical() << "error from" << iface->interface() << "=" << cdev_count.error();
+        qCritical() << "error from" << iface->interface() << "=" << z_count.error();
         return false;
     }
 


### PR DESCRIPTION
fix https://github.com/intel/thermal_daemon/issues/311