### PR TITLE
Benzea/adaptive improvements

### DIFF
--- a/src/thd_engine.h
+++ b/src/thd_engine.h
@@ -148,7 +148,8 @@ public:
 		return control_mode;
 	}
 	void thd_engine_thread();
-	virtual int thd_engine_start(bool ignore_cpuid_check, bool adaptive = false);
+	virtual int thd_engine_init(bool ignore_cpuid_check, bool adaptive = false);
+	virtual int thd_engine_start();
 	int thd_engine_stop();
 	int check_cpu_id();
 

--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -1032,6 +1032,11 @@ int cthd_engine_adaptive::evaluate_platform_type_condition(
 	int value = 1;
 
 	if (tablet_dev) {
+		struct input_event ev;
+
+		while (libevdev_has_event_pending(tablet_dev))
+			libevdev_next_event(tablet_dev, LIBEVDEV_READ_FLAG_NORMAL, &ev);
+
 		int tablet = libevdev_get_event_value(tablet_dev, EV_SW,
 				SW_TABLET_MODE);
 		if (tablet)

--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -88,9 +88,19 @@ class _gddv_exception: public std::exception {
 	}
 } gddv_exception;
 
+void cthd_engine_adaptive::destroy_dynamic_sources() {
+	g_clear_object(&upower_client);
+	g_clear_object(&power_profiles_daemon);
+
+	if (tablet_dev) {
+		close(libevdev_get_fd(tablet_dev));
+		libevdev_free(tablet_dev);
+		tablet_dev = NULL;
+	}
+}
+
 cthd_engine_adaptive::~cthd_engine_adaptive() {
-	g_clear_object (&upower_client);
-	g_clear_object (&power_profiles_daemon);
+	destroy_dynamic_sources();
 }
 
 int cthd_engine_adaptive::get_type(char *object, int *offset) {
@@ -1687,10 +1697,7 @@ int cthd_engine_adaptive::thd_engine_start(bool ignore_cpuid_check, bool adaptiv
 			thd_log_info("Also unable to evaluate any conditions\n");
 			thd_log_info("Falling back to use configuration with the highest power\n");
 
-			if (tablet_dev)
-				libevdev_free(tablet_dev);
-
-			// Looks like there is no free call for up_client_new()
+			destroy_dynamic_sources();
 
 			int i = find_agressive_target();
 			thd_log_info("target:%d\n", i);

--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -1551,7 +1551,7 @@ void cthd_engine_adaptive::setup_input_devices() {
 		int fd = -1;
 
 		snprintf(fname, sizeof(fname), "/dev/input/%s", namelist[i]->d_name);
-		fd = open(fname, O_RDONLY);
+		fd = open(fname, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
 		if (fd < 0)
 			continue;
 		ret = libevdev_new_from_fd(fd, &tablet_dev);

--- a/src/thd_engine_adaptive.h
+++ b/src/thd_engine_adaptive.h
@@ -164,6 +164,7 @@ protected:
 
 	int power_slider;
 
+	void destroy_dynamic_sources();
 	int get_type(char *object, int *offset);
 	uint64_t get_uint64(char *object, int *offset);
 	char* get_string(char *object, int *offset);

--- a/src/thd_engine_adaptive.h
+++ b/src/thd_engine_adaptive.h
@@ -218,7 +218,8 @@ public:
 
 	~cthd_engine_adaptive();
 	ppcc_t* get_ppcc_param(std::string name);
-	int thd_engine_start(bool ignore_cpuid_check, bool adaptive);
+	int thd_engine_init(bool ignore_cpuid_check, bool adaptive);
+	int thd_engine_start();
 	void update_engine_state();
 	void update_power_slider();
 };

--- a/src/thd_engine_adaptive.h
+++ b/src/thd_engine_adaptive.h
@@ -155,6 +155,7 @@ protected:
 	UpClient *upower_client;
 	GDBusProxy *power_profiles_daemon;
 	struct libevdev *tablet_dev;
+	struct libevdev *lid_dev;
 	int current_condition_set;
 	int policy_active;
 	int fallback_id;

--- a/src/thd_engine_default.cpp
+++ b/src/thd_engine_default.cpp
@@ -841,7 +841,15 @@ int thd_engine_create_default_engine(bool ignore_cpuid_check,
 	if (conf_file)
 		thd_engine->set_config_file(conf_file);
 
-	res = thd_engine->thd_engine_start(ignore_cpuid_check);
+	res = thd_engine->thd_engine_init(ignore_cpuid_check);
+	if (res != THD_SUCCESS) {
+		if (res == THD_FATAL_ERROR)
+			thd_log_error("THD engine init failed\n");
+		else
+			thd_log_msg("THD engine init failed\n");
+	}
+
+	res = thd_engine->thd_engine_start();
 	if (res != THD_SUCCESS) {
 		if (res == THD_FATAL_ERROR)
 			thd_log_error("THD engine start failed\n");


### PR DESCRIPTION
Some general improvements, this includes:
 * #335 (p-p-d integration for Power_slider)
 * Properly reading evdev devices
 * Splitting thd_engine_start into two; as otherwise we may print useless warnings (sensors are read too late for condition verification)
 * Using libevdev to read lid state rather than upower (the functionality is deprecated)
 * Improved cleanup code