### PR TITLE
Fix test for compressed data vaults

### DIFF
--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -766,7 +766,7 @@ int cthd_engine_adaptive::parse_gddv(char *buf, int size, int *end_offset) {
 		char name[ESIFDV_NAME_LEN + 1] = { 0 };
 		char comment[ESIFDV_DESC_LEN + 1] = { 0 };
 
-		if (header->v2.flags == ESIF_SERVICE_CONFIG_COMPRESSED) {
+		if (header->v2.flags & ESIF_SERVICE_CONFIG_COMPRESSED) {
 			thd_log_debug("Uncompress GDDV payload\n");
 			return handle_compressed_gddv(buf, size);
 		}


### PR DESCRIPTION
As can be seen in https://github.com/intel/dptf/blob/master/ESIF/Products/ESIF_LIB/Sources/esif_lib_datavault.c#L980 ,
we should be testing for whether the compressed flag is set and not whether
the flags field is equal to the compressed flag.