### PR TITLE
Add RaptorLake CPU models

### DIFF
--- a/src/thd_engine.cpp
+++ b/src/thd_engine.cpp
@@ -711,6 +711,8 @@ static supported_ids_t id_table[] = {
 		{ 6, 0x9c }, // Jasper Lake
 		{ 6, 0x97 }, // Alderlake
 		{ 6, 0x9a }, // Alderlake
+		{ 6, 0xb7 }, // Raptorlake
+		{ 6, 0xba }, // Raptorlake
 		{ 0, 0 } // Last Invalid entry
 };
 


### PR DESCRIPTION
These were added upstream in the kernel already.

Note that I have *not* tested this. As such, it might be that further changes are needed, however, I am assuming that simply adding the CPU IDs is sufficient.