### PR TITLE
Ensure there is one trips element per zone

### DIFF
--- a/tools/thermal_monitor/mainwindow.cpp
+++ b/tools/thermal_monitor/mainwindow.cpp
@@ -116,6 +116,9 @@ void MainWindow::setupPlotWidget()
     currentTempsensorIndex = 0;
     int active_zone = 0;
     for (uint zone = 0; zone < m_thermaldInterface->getZoneCount(); zone++) {
+        // Trips is indexed by zone. We need to make sure there is a tips item
+        // (even if empty) for each zone.
+        trips.append(QVector<QCPItemLine *>());
 
         zoneInformationType *zone_info = m_thermaldInterface->getZone(zone);
         if (!zone_info)
@@ -180,7 +183,7 @@ void MainWindow::setupPlotWidget()
                 }
                 these_trips.append(line);
             }
-            trips.append(these_trips);
+            trips.last().swap(these_trips);
         }
     }
 


### PR DESCRIPTION
In some cases a trip element was not added for every zone, causing an
out-of-bound access to the trips vector (which is indexed by zone number).

In this change we ensure that a (possinly empty) trips element is added for
each zone.