### PR TITLE
main: Handle signals from mainloop

### DIFF
--- a/src/thd_dbus_interface.cpp
+++ b/src/thd_dbus_interface.cpp
@@ -188,11 +188,11 @@ gboolean thd_dbus_interface_get_current_preference(PrefObject *obj,
 	return TRUE;
 }
 
-void (*thd_dbus_exit_callback)(int);
+gboolean (*thd_dbus_exit_callback)(void);
 gboolean thd_dbus_interface_terminate(PrefObject *obj, GError **error) {
 	thd_engine->thd_engine_terminate();
 	if (thd_dbus_exit_callback)
-		thd_dbus_exit_callback(0);
+		thd_dbus_exit_callback();
 
 	return TRUE;
 }
@@ -578,7 +578,7 @@ gboolean thd_dbus_interface_get_sensor_temperature(PrefObject *obj, int index,
 }
 
 // Setup dbus server
-int thd_dbus_server_init(void (*exit_handler)(int)) {
+int thd_dbus_server_init(gboolean (*exit_handler)(void)) {
 	DBusGConnection *bus;
 	DBusGProxy *bus_proxy;
 	GError *error = NULL;


### PR DESCRIPTION
The signal handler ends up calling quite a lot of code, not all of this
code is signal safe. Fix the issue by instead using the GLib
infrastructure to execute the code from the mainloop instead.

Note that there are probably more cleanups to be had here. But this is
sufficient to fix the signal safety.

Fixes: #361