### PR TITLE
Manual: thermal-conf.xml - clean up lintian warnings and .IP formatting

### DIFF
--- a/man/thermal-conf.xml.5
+++ b/man/thermal-conf.xml.5
@@ -30,34 +30,63 @@ $(TDCONFDIR)/etc/thermald/thermal-conf.xml
 
 .SH DESCRIPTION
 .B thermal-conf.xml
-is a configuration file for the thermal daemon. It is used to configure thermal sensors, zone and cooling devices.The location of this file depends on the configuration option used during build time.
+is a configuration file for the thermal daemon. It is used to configure 
+thermal sensors, zone and cooling devices. The location of this file depends
+on the configuration option used during build time.
 .PP
-The terminology used in this file conforms to "Advanced Configuration and Power Interface Specification". The ACPI thermal model is based around conceptual platform regions called thermal zones that physically contain devices, thermal sensors, and cooling controls. For example of a thermal zone can be a CPU or a laptop cover. A zone can contain multiple sensors for monitoring temperature. A cooling device provides interface to reduce the temperature of a source device, which causes increase in the temperature. An example of a cooling device is a FAN or some Linux driver which can throttle the source device.
+The terminology used in this file conforms to "Advanced Configuration and Power
+Interface Specification". The ACPI thermal model is based around conceptual
+platform regions called thermal zones that physically contain devices, thermal
+sensors, and cooling controls. For example of a thermal zone can be a CPU or a
+laptop cover. A zone can contain multiple sensors for monitoring temperature. A
+cooling device provides interface to reduce the temperature of a source device,
+which causes increase in the temperature. An example of a cooling device is a
+FAN or some Linux driver which can throttle the source device.
 .PP
-A thermal zone configuration includes one or more trip points. A trip point is a temperature at which a cooling device needs to be activated.
+A thermal zone configuration includes one or more trip points. A trip point is
+a temperature at which a cooling device needs to be activated.
 .PP
-A cooling device can be either active or passive. An example of an active device is a FAN, which will not reduce performance at the cost of consuming more power and noise. A passive device uses performance throttling to control temperature. In addition to cooling devices present in the thermal sysfs, the following cooling devices are built into the thermald, which can be used as valid cooling device type:
-.IP
-	- rapl_controller
-.IP
-	- intel_pstate
-.IP
-	- cpufreq
-.IP
-	- LCD
-.PP
-The thermal sysfs under Linux (/sys/class/thermal) provides a way to represent per platform ACPI configuration. The kernel thermal governor uses this data to keep the platform thermals under control. But there are some limitations, which thermald tries to resolve. For example:
+A cooling device can be either active or passive. An example of an active
+device is a FAN, which will not reduce performance at the cost of consuming
+more power and noise. A passive device uses performance throttling to control
+temperature. In addition to cooling devices present in the thermal sysfs, the
+following cooling devices are built into the thermald, which can be used as
+valid cooling device type:
 .TP
-- If the ACPI data is not optimized or buggy. In this case thermal-conf.xml can be used to correct the behavior without change in BIOS.
-.IP
-- There may be thermal zones exposed by the thermal sysfs without associated cooling actions. In this case thermal conf.xml can be used to tie the cooling devices to those zones.
-.IP
-- The best cooling method may not be in the thermal sysfs. In this case thermal-conf.xml can be used to bind a zone to an external cooling device.
-.IP
-- Specify thermal relationships. A zone can be influenced by multiple source devices with varying degrees. In this case thermal-conf.xml can be used to define the relative influence for apply compensation.
-
+.PP
+.IP \(bu 2
+rapl_controller
+.IP \(bu 2
+intel_pstate
+.IP \(bu 2
+cpufreq
+.IP \(bu 2
+LCD
+.PP
+The thermal sysfs under Linux (/sys/class/thermal) provides a way to represent
+per platform ACPI configuration. The kernel thermal governor uses this data to
+keep the platform thermals under control. But there are some limitations, which
+thermald tries to resolve. For example:
+.TP
+.PP
+.IP \(bu 2
+If the ACPI data is not optimized or buggy. In this case thermal-conf.xml
+can be used to correct the behavior without change in BIOS.
+.IP \(bu 2
+There may be thermal zones exposed by the thermal sysfs without associated
+cooling actions. In this case thermal conf.xml can be used to tie the cooling
+devices to those zones.
+.IP \(bu 2
+The best cooling method may not be in the thermal sysfs. In this case
+thermal-conf.xml can be used to bind a zone to an external cooling device.
+.IP \(bu 2
+Specify thermal relationships. A zone can be influenced by multiple source
+devices with varying degrees. In this case thermal-conf.xml can be used to
+define the relative influence for apply compensation.
+.PP
 .SH FILE FORMAT
-The configuration file format conforms to XML specifications. A set of tags defined to define platform, sensors, zones, cooling devices and trip points.
+The configuration file format conforms to XML specifications. A set of tags
+defined to define platform, sensors, zones, cooling devices and trip points.
 .sp 1
 .EX
 <ThermalConfiguration>
@@ -163,7 +192,9 @@ The configuration file format conforms to XML specifications. A set of tags defi
 .SH EXAMPLE CONFIGURATIONS
 .PP
 .B Example 1:
-This is a very simple configuration, to change the passive limit on the CPU. Instead of default, this new temperature 86C in the configuration is used. This will start cooling, once the temperature reaches 86C.
+This is a very simple configuration, to change the passive limit on the
+CPU. Instead of default, this new temperature 86C in the configuration is
+used. This will start cooling, once the temperature reaches 86C.
 .sp 1
 .EX
 <?xml version="1.0"?>
@@ -188,7 +219,12 @@ This is a very simple configuration, to change the passive limit on the CPU. Ins
 .EE
 .PP
 .B Example 2:
-In this configuration, we are controlling backlight when some sensor "SEN2" reaches 60C. Here "LCD" is a standard cooling device, which uses Linux backlight sysfs interface. "LCD_Zone" is a valid thermal zone in Linux thermal sysfs on the test platform, hence we don't need to provide path for sysfs for "LCD_Zone". The Linux thermal sysfs is already parsed and loaded by thermald program.
+In this configuration, we are controlling backlight when some sensor "SEN2"
+reaches 60C. Here "LCD" is a standard cooling device, which uses Linux
+backlight sysfs interface. "LCD_Zone" is a valid thermal zone in Linux
+thermal sysfs on the test platform, hence we don't need to provide path for
+sysfs for "LCD_Zone". The Linux thermal sysfs is already parsed and loaded
+by the thermald program.
 .sp 1
 .EX
 <?xml version="1.0"?>
@@ -217,8 +253,11 @@ In this configuration, we are controlling backlight when some sensor "SEN2" reac
 .EE
 .PP
 .B Example 3:
-In this example Lenovo Thinkpad X220 and fan speed is controlled. Here a cooling device "_Fan", can be controlled via sysfs
-/sys/devices/platform/thinkpad_hwmon/pwm1. When the x86_pkg_temp reaches 45C, Fan is started with increasing speeds, if the temperature can't be controlled at 45C.
+In this example Lenovo Thinkpad X220 and fan speed is controlled. Here a
+cooling device "_Fan", can be controlled via sysfs
+/sys/devices/platform/thinkpad_hwmon/pwm1. When the x86_pkg_temp reaches 45C,
+Fan is started with increasing speeds, if the temperature can't be
+controlled at 45C.
 .sp 1
 .EX
 <?xml version="1.0"?>
@@ -262,7 +301,11 @@ In this example Lenovo Thinkpad X220 and fan speed is controlled. Here a cooling
 .EE
 .PP
 .B Example 4:
-The following example shows how PID can be used. Here once temperature exceeds 80C, compensation is calculated using PID using 80C as set point of PID. The compensation depends on error from the set point. Here the default built in processor cooling device is used with min state as 0 and max state as 10.
+The following example shows how PID can be used. Here once temperature
+exceeds 80C, compensation is calculated using PID using 80C as set point of
+PID. The compensation depends on error from the set point. Here the default
+built in processor cooling device is used with min state as 0 and max state
+as 10.
 .sp 1
 .EX
 <?xml version="1.0"?>
@@ -302,7 +345,9 @@ The following example shows how PID can be used. Here once temperature exceeds 8
 .EE
 .PP
 .B Example 5:
-The following example shows how to control Fan when the sysfs expects some string prefix. For example instead of just write a number to fan control sysfs, the interface requires "level " in front of the speed index value.
+The following example shows how to control Fan when the sysfs expects some
+string prefix. For example instead of just write a number to fan control
+sysfs, the interface requires "level " in front of the speed index value.
 .sp 1
 .EX
 <?xml version="1.0"?>


### PR DESCRIPTION
The debian packaging lintian checker is complaining that some of the
lines in the manual are very long. Break these up to sub-80 char wide
lines to clean these warnings up.  Also, fix up the .IP formatting as
the intentation is a bit broken. Add bullet points in .IP formatting
for some style too.

Signed-off-by: Colin Ian King <colin.i.king@gmail.com>