### PR TITLE
configure.ac: Install dbus policy in /usr/share, not /etc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_ARG_WITH(dbus-sys-dir, AS_HELP_STRING([--with-dbus-sys-dir=DIR], [where D-BUS
 if test -n "$with_dbus_sys_dir" ; then
     DBUS_SYS_DIR="$with_dbus_sys_dir"
 else
-    DBUS_SYS_DIR="/etc/dbus-1/system.d"
+    DBUS_SYS_DIR="/usr/share/dbus-1/system.d"
 fi
 AC_SUBST(DBUS_SYS_DIR)
 

--- a/distribution_integration/thermal-daemon.spec
+++ b/distribution_integration/thermal-daemon.spec
@@ -46,7 +46,7 @@ make %{?_smp_mflags}
 
 %files
 %{_sbindir}/thermald
-%config(noreplace) %{_sysconfdir}/dbus-1/system.d/org.freedesktop.thermald.conf
+%{_datadir}/dbus-1/system.d/org.freedesktop.thermald.conf
 %{_datadir}/dbus-1/system-services/org.freedesktop.thermald.service
 %config(noreplace) %{_sysconfdir}/thermald/thermal-conf.xml
 %config(noreplace) %{_sysconfdir}/thermald/thermal-cpu-cdev-order.xml


### PR DESCRIPTION
From https://bugs.debian.org/1006631:

> dbus supports policy files in both `/usr/share/dbus-1/system.d` and
> `/etc/dbus-1/systemd`. [The] recently released dbus 1.14.0, officially
> deprecates installing packages' default policies into `/etc/dbus-1/systemd`,
> instead reserving it for the sysadmin. This is the same idea as the
> difference between `/usr/lib/udev/rules.d` and `/etc/udev/rules.d`.