### PR TITLE
Make the dbus power group configurable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,14 @@ else
 fi
 AC_SUBST(DBUS_SYS_DIR)
 
+AC_ARG_WITH(dbus-power-group, AS_HELP_STRING([--with-dbus-power-group=GROUP], [group that is allowed to connect to D-BUS service]))
+if test -n "$with_dbus_power_group" ; then
+    DBUS_POWER_GROUP="$with_dbus_power_group"
+else
+    DBUS_POWER_GROUP="power"
+fi
+AC_SUBST(DBUS_POWER_GROUP)
+
 # paths
 AC_SUBST(tdbinary, "$sbindir/$PACKAGE", [Binary executable])
 AC_SUBST(tdconfdir, "$sysconfdir/$PACKAGE", [Configuration directory])

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,28 +1,38 @@
 include $(GLIB_MAKEFILE)
 
 if HAVE_SYSTEMD
+
 systemdsystemunit_DATA = \
 	thermald.service
 
 thermald.service: thermald.service.in
-	@$(edit) $< >$@
+	@$(service_edit) $< >$@
 
 servicedir = $(datadir)/dbus-1/system-services
 service_in_files = org.freedesktop.thermald.service.in
 service_DATA = $(service_in_files:.service.in=.service)
 
 $(service_DATA): $(service_in_files) Makefile
-	@$(edit) $< >$@
-endif
+	@$(service_edit) $< >$@
 
-edit = sed \
+service_edit = sed \
 	-e 's|@bindir[@]|$(bindir)|g' \
 	-e 's|@sbindir[@]|$(sbindir)|g' \
 	-e 's|@sysconfdir[@]|$(sysconfdir)|g' \
 	-e 's|@localstatedir[@]|$(localstatedir)|g'
 
+endif # HAVE_SYSTEMD
+
+dbusservice_edit = sed \
+	-e 's|@dbusservicepowergrp[@]|$(dbusservicepowergrp)|g'
+
+org.freedesktop.thermald.conf: org.freedesktop.thermald.conf.in
+	@$(dbusservice_edit) $< >$@
+
+dbusservicepowergrp = $(DBUS_POWER_GROUP)
 dbusservicedir = $(DBUS_SYS_DIR)
-dbusservice_DATA = org.freedesktop.thermald.conf
+dbusservice_in_files = org.freedesktop.thermald.conf.in
+dbusservice_DATA = $(dbusservice_in_files:.conf.in=.conf)
 
 tdconfigdir = $(tdconfdir)
 tdconfig_DATA = \

--- a/data/org.freedesktop.thermald.conf.in
+++ b/data/org.freedesktop.thermald.conf.in
@@ -10,13 +10,13 @@
                 <allow receive_sender="org.freedesktop.thermald"/>
         </policy>
 
-        <!-- Only allow members of the power group to communicate
+        <!-- Only allow members of the @dbusservicepowergrp@ group to communicate
              with the daemon -->
         <policy context="default">
                 <deny send_destination="org.freedesktop.thermald"/>
                 <allow receive_sender="org.freedesktop.thermald"/>
         </policy>
-        <policy group="power">
+        <policy group="@dbusservicepowergrp@">
                 <allow send_destination="org.freedesktop.thermald"/>
                 <allow receive_sender="org.freedesktop.thermald"/>
         </policy>

--- a/tools/thermal_monitor/README
+++ b/tools/thermal_monitor/README
@@ -26,8 +26,9 @@ Open Qt Creator, click File->Open File or Project, browse the project files to o
 
 Running the project
 -------------------
-To communicate with thermald via dbus, the user has to be member of "power" group.
-So make sure that there is group called "power" in the system and add your user id to this group.
+To communicate with thermald via dbus, the user has to be member of a group able to manage power.
+So make sure that there is a power related group the system and add your user id to this group.
+On some sytems this group will be called "power" and on others it may be called "powerdev".
 
 Building the Thermal Monitor with make
 --------------------------------------

--- a/tools/thermal_monitor/main.cpp
+++ b/tools/thermal_monitor/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
     if (!thermaldInterface.initialize()) {
         QMessageBox::critical(0, "Can't establish link with thermal daemon.",
                               "Make sure that thermal daemon started with --dbus-enable option\n"
-                              "and that you're in the 'power' group.");
+                              "and that you're in the power management group ('power', 'powerdev' etc).");
         return 1;
     }
 


### PR DESCRIPTION
This means that distros can choose their pre-existing power management group
or just choose a less generic group than 'power' such as '_thermald-managers'.

Closes: https://github.com/intel/thermal_daemon/issues/162
See-also: https://bugs.debian.org/864502
