### PR TITLE
Clean up typos, grammar, shebangs, regex, commands, links, paths, manual pages

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -65,17 +65,17 @@ add appropriate prefix.
 
 Building on Ubuntu
 1. Install
-	sudo apt-get install autoconf
-	sudo apt-get install autoconf-archive
-	sudo apt-get install g++
-	sudo apt-get install libglib2.0-dev
-	sudo apt-get install libdbus-1-dev
-	sudo apt-get install libdbus-glib-1-dev
-	sudo apt-get install libxml2-dev
-	sudo apt-get install gtk-doc-tools
-	sudo apt-get install libupower-glib-dev
-	sudo apt-get install liblzma-dev
-	sudo apt-get install libevdev-dev
+	sudo apt install autoconf
+	sudo apt install autoconf-archive
+	sudo apt install g++
+	sudo apt install libglib2.0-dev
+	sudo apt install libdbus-1-dev
+	sudo apt install libdbus-glib-1-dev
+	sudo apt install libxml2-dev
+	sudo apt install gtk-doc-tools
+	sudo apt install libupower-glib-dev
+	sudo apt install liblzma-dev
+	sudo apt install libevdev-dev
 
 2
 Build

--- a/README.txt
+++ b/README.txt
@@ -210,7 +210,7 @@ Release 1.9.1
 Release 1.9
 - The major change in this version is the active power limits adjustment.
 This will be useful to improve performance on some newer platform. But
-this will will lead to increase in CPU and other temperatures. Hence this
+this will lead to increase in CPU and other temperatures. Hence this
 is important to run dptfxtract version 1.4.1 tool to get performance
 sensitive thermal limits (https://github.com/intel/dptfxtract/commits/v1.4.1).
 If the default configuration picked up by thermald is not optimal, user
@@ -225,8 +225,8 @@ secure boot must update to newer kernels.
 
 - TCC offset limits
 As reported in some forums that some platforms have issue with high TCC
-offset settings. Under some special condition this offset is adjusted.
-But currently needs msr module loaded to get MSR access
+offset settings. Under some special condition this offset is adjusted,
+but that currently needs msr module loaded to get MSR access
 from user space. I have submitted a patch to have this exported via sysfs
 for v5.4+ kernel.
 
@@ -414,7 +414,7 @@ on slope and angular increments to dynamically adjust set point
 
 
 Version 0.2
-- Define XML interface to set configuration data. Refer to thermal-conf.xml. This allows to override buggy Bios thermal comfiguration and also allows to extend the capability.
+- Define XML interface to set configuration data. Refer to thermal-conf.xml. This allows overriding buggy Bios thermal comfiguration and also allows extending the capability.
 - Use platform DMI UUID to index into configuration data. If there is no UUID match, falls back to thermal sysfs
 - Terminate interface
 - Takes over control from kernel thermal processing

--- a/data/thermal-conf.xml
+++ b/data/thermal-conf.xml
@@ -71,7 +71,7 @@ use "man thermal-conf.xml" for details
 			<AsyncCapable>1</AsyncCapable>
 		</ThermalSensor>
 		<ThermalSensor>
-			<!-- Examle of a virtual sensor. This sensor
+			<!-- Example of a virtual sensor. This sensor
 				depends on other real sensor or
 				virtual sensor.
 				E.g. here the temp will be

--- a/distribution_integration/chromeos_gentoo_ebuild_spec
+++ b/distribution_integration/chromeos_gentoo_ebuild_spec
@@ -7,8 +7,8 @@ EAPI=4
 inherit autotools systemd
 
 DESCRIPTION="Thermal daemon for Intel architectures"
-HOMEPAGE="https://01.org/linux-thermal-daemon"
-SRC_URI="https://github.com/01org/thermal_daemon/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://github.com/intel/thermal_daemon"
+SRC_URI="https://github.com/intel/thermal_daemon/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/distribution_integration/make_rpm.sh
+++ b/distribution_integration/make_rpm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-BRANCH=$(git branch | grep '^*' | sed 's/^..\(.*\)/\1/')
+BRANCH=$(git branch | grep '^\*' | sed 's/^..\(.*\)/\1/')
 HASH=$(git rev-parse ${BRANCH})
 TAG=$(git describe --tags --abbrev=0)
 RELEASE=$(git describe --tags | cut -d- -f2 | tr - _)

--- a/distribution_integration/thermal-daemon.spec
+++ b/distribution_integration/thermal-daemon.spec
@@ -4,9 +4,9 @@ Release:        1%{?dist}
 Summary:        The "Linux Thermal Daemon" program from 01.org
 
 License:        GPLv2+
-URL:            https://github.com/01org/thermal_daemon
+URL:            https://github.com/intel/thermal_daemon
 %global         pkgname thermal_daemon
-Source0:        https://github.com/01org/thermal_daemon/archive/v%{version}.tar.gz
+Source0:        https://github.com/intel/thermal_daemon/archive/v%{version}.tar.gz
 
 BuildRequires:    automake
 BuildRequires:    autoconf

--- a/docs/thermal_daemon-docs.xml
+++ b/docs/thermal_daemon-docs.xml
@@ -34,7 +34,7 @@
 	Texts. You may obtain a copy of the <citetitle>GNU Free
 	Documentation License</citetitle> from the Free Software
 	Foundation by visiting <ulink type="http"
-	url="http://www.fsf.org">their Web site</ulink> or by writing
+	url="https://www.fsf.org">their Web site</ulink> or by writing
 	to:
 
 	<address>

--- a/man/thermal-conf.xml.5
+++ b/man/thermal-conf.xml.5
@@ -21,7 +21,7 @@
 .\"
 .\" Copyright (C) 2012 Intel Corporation. All rights reserved.
 .\"
-.TH thermal-conf.xml "5" "18 Dec 2018"
+.TH thermal-conf.xml "5" "Dec 18, 2018"
 
 .SH NAME
 thermal-conf.xml \- Configuration file for thermal daemon

--- a/man/thermal-conf.xml.5
+++ b/man/thermal-conf.xml.5
@@ -52,8 +52,6 @@ more power and noise. A passive device uses performance throttling to control
 temperature. In addition to cooling devices present in the thermal sysfs, the
 following cooling devices are built into the thermald, which can be used as
 valid cooling device type:
-.TP
-.PP
 .IP \(bu 2
 rapl_controller
 .IP \(bu 2
@@ -67,8 +65,6 @@ The thermal sysfs under Linux (/sys/class/thermal) provides a way to represent
 per platform ACPI configuration. The kernel thermal governor uses this data to
 keep the platform thermals under control. But there are some limitations, which
 thermald tries to resolve. For example:
-.TP
-.PP
 .IP \(bu 2
 If the ACPI data is not optimized or buggy. In this case thermal-conf.xml
 can be used to correct the behavior without change in BIOS.
@@ -83,7 +79,6 @@ thermal-conf.xml can be used to bind a zone to an external cooling device.
 Specify thermal relationships. A zone can be influenced by multiple source
 devices with varying degrees. In this case thermal-conf.xml can be used to
 define the relative influence for apply compensation.
-.PP
 .SH FILE FORMAT
 The configuration file format conforms to XML specifications. A set of tags
 defined to define platform, sensors, zones, cooling devices and trip points.
@@ -190,7 +185,6 @@ defined to define platform, sensors, zones, cooling devices and trip points.
 </ThermalConfiguration>
 .EE
 .SH EXAMPLE CONFIGURATIONS
-.PP
 .B Example 1:
 This is a very simple configuration, to change the passive limit on the
 CPU. Instead of default, this new temperature 86C in the configuration is

--- a/man/thermald.8
+++ b/man/thermald.8
@@ -21,7 +21,7 @@
 .\"
 .\" Copyright (C) 2012 Intel Corporation. All rights reserved.
 .\"
-.TH thermald "8" "8 May 2013"
+.TH thermald "8" "May 8, 2013"
 
 .SH NAME
 thermald \- start Linux thermal daemon

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,7 @@
  */
 
 /* This implements main() function. This will parse command line options and
- * a new instance of cthd_engine object. By default it will create a engine
+ * a new instance of cthd_engine object. By default it will create an engine
  * which uses dts engine, which DTS sensor and use P states to control
  * temperature, without any configuration. Alternatively if the
  * thermal-conf.xml has exact UUID match then it can use the zones and

--- a/src/thd_cdev_intel_pstate_driver.cpp
+++ b/src/thd_cdev_intel_pstate_driver.cpp
@@ -25,7 +25,7 @@
 #include "thd_cdev_intel_pstate_driver.h"
 
 /*
- * This implementation allows to control get max state and
+ * This implementation allows controlling get max state and
  * set current state of using Intel P state driver
  * P state drives uses a percent count. 100% means full
  * performance, setting anything lower limits performance.

--- a/src/thd_engine.cpp
+++ b/src/thd_engine.cpp
@@ -992,7 +992,7 @@ cthd_zone* cthd_engine::get_zone(std::string type) {
 }
 
 // Code copied from
-// https://rt.wiki.kernel.org/index.php/RT_PREEMPT_HOWTO#Runtime_detection_of_an_RT-PREEMPT_Kernel
+// https://web.archive.org/web/20130822155153/https://rt.wiki.kernel.org/index.php/RT_PREEMPT_HOWTO#Runtime_detection_of_an_RT-PREEMPT_Kernel
 void cthd_engine::check_for_rt_kernel() {
 	struct utsname _uname;
 	char *crit1 = NULL;

--- a/src/thd_gddv.cpp
+++ b/src/thd_gddv.cpp
@@ -678,7 +678,7 @@ void cthd_gddv::parse_idsp(char *name, char *start, int length) {
 		char idsp[64];
 		std::string idsp_str;
 
-		// The minimum length for a IDSP should be at least 28
+		// The minimum length for an IDSP should be at least 28
 		// including headers and values
 		if ((length - i) < 28)
 			return;

--- a/src/thd_trt_art_reader.cpp
+++ b/src/thd_trt_art_reader.cpp
@@ -59,7 +59,7 @@ typedef enum {
  * The _TRT and _ART table may refer to entry, for which we have
  * we need to tie to some control device, which is not enumerated
  * as a thermal cooling device. In this case, we substitute them
- * to a inbuilt standard name.
+ * to an inbuilt standard name.
  */
 static void associate_device(sub_type_t type, string &name) {
 	DIR *dir;

--- a/src/thd_zone_cpu.cpp
+++ b/src/thd_zone_cpu.cpp
@@ -20,7 +20,7 @@
  *
  * Author Name <Srinivas.Pandruvada@linux.intel.com>
  *
- * This implementation allows to use core temperature interface.
+ * This implementation allows using core temperature interface.
  */
 
 /* Implementation of DTS sensor Zone. This
@@ -106,7 +106,7 @@ int cthd_zone_cpu::init() {
 	}
 
 	// max_temperature is where the Fan would have been activated fully
-	// psv_temp is set more that that so that in case if Fan is not able to
+	// psv_temp is set more so that in the case if Fan is not able to
 	// control temperature, the passive temperature will be acted on
 	psv_temp = max_temp + ((critical_temp - max_temp) / 2);
 

--- a/src/thd_zone_cpu.h
+++ b/src/thd_zone_cpu.h
@@ -20,7 +20,7 @@
  *
  * Author Name <Srinivas.Pandruvada@linux.intel.com>
  *
- * This interface allows to override per zone read data from sysfs for
+ * This interface allows overriding per zone read data from sysfs for
  * buggy BIOS.
  */
 

--- a/test/cpufreq.sh
+++ b/test/cpufreq.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 
 CONF_FILE="/var/run/thermald/thermal-conf.xml.auto"
 

--- a/test/intel_pstate.sh
+++ b/test/intel_pstate.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 
 CONF_FILE="/var/run/thermald/thermal-conf.xml.auto"
 

--- a/test/thermald_optimization_with_dptfxtract
+++ b/test/thermald_optimization_with_dptfxtract
@@ -49,12 +49,12 @@ DPTF Tables Extraction Utility
 Copyright (c) 2000 - 2019 Intel Corporation
 
 
-Output file file is /etc/thermald/thermal-conf.xml.0
-Output file file is /etc/thermald/thermal-conf.xml.1
-Output file file is /etc/thermald/thermal-conf.xml.2
-Output file file is /etc/thermald/thermal-conf.xml.3
-Output file file is /etc/thermald/thermal-conf.xml.4
-Output file file is /etc/thermald/thermal-conf.xml.auto
+Output file is /etc/thermald/thermal-conf.xml.0
+Output file is /etc/thermald/thermal-conf.xml.1
+Output file is /etc/thermald/thermal-conf.xml.2
+Output file is /etc/thermald/thermal-conf.xml.3
+Output file is /etc/thermald/thermal-conf.xml.4
+Output file is /etc/thermald/thermal-conf.xml.auto
 
 Step 6
 Check the kernel version, using " uname -a".

--- a/tools/thermal_monitor/README
+++ b/tools/thermal_monitor/README
@@ -32,7 +32,7 @@ So make sure that there is group called "power" in the system and add your user 
 Building the Thermal Monitor with make
 --------------------------------------
 
-Normally Qt Creator handles the compilation of the project.  If you wish to use the command line to compile, then you first have to create a makefile.  Qmake will create the makefile for you based on the project file.  Qmake resided in /opt/Qt/5.4/gcc_64/bin on our system.  Invoke with:
+Normally Qt Creator handles the compilation of the project.  If you wish to use the command line to compile, then you first have to create a makefile.  Qmake will create the makefile for you based on the project file.  Invoke with:
 
 qmake ThermalMonitor.pro
 

--- a/tools/thermal_monitor/thermaldinterface.cpp
+++ b/tools/thermal_monitor/thermaldinterface.cpp
@@ -63,7 +63,7 @@ bool ThermaldInterface::initialize()
         return false;
     }
 
-    // Read in all the the temperature sensor data from the thermal daemon
+    // Read in all the temperature sensor data from the thermal daemon
     for (uint i = 0; i < sensor_count; i++){
         sensorInformationType new_sensor;
 


### PR DESCRIPTION
- Fix typos and grammar
- Fix shell script header shebangs
- Fix regex for finding the current branch
- Switch from apt-get to apt for installing Ubuntu dependencies
- Drop mention of where qmake is installed
- Update links for https, redirects, moved repos and archived pages
- Fix dates in manual pages
- Drop empty/skipped .TP and .PP in manual pages
