### PR TITLE
Update the QCustomPlot library name

### DIFF
--- a/tools/thermal_monitor/ThermalMonitor.pro
+++ b/tools/thermal_monitor/ThermalMonitor.pro
@@ -14,7 +14,7 @@ CONFIG(release): DEFINES += QT_NO_DEBUG_OUTPUT
 TARGET = ThermalMonitor
 TEMPLATE = app
 
-LIBS += -lqcustomplot
+LIBS += -lQCustomPlot
 
 SOURCES += main.cpp\
         mainwindow.cpp \


### PR DESCRIPTION
The library name was changed to title case in QCustomPlot 2.1.0.
