### PR TITLE
Migrate from dbus-glib to GDBus

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,8 @@ thermald_LDADD = \
 	$(EVDEV_LIBS)
 
 BUILT_SOURCES = \
-	thd_dbus_interface.h
+	thd_dbus_interface.h \
+	thermald_resources.c
 
 thermald_SOURCES = \
 	src/main.cpp \
@@ -93,7 +94,7 @@ man8_MANS = man/thermald.8
 thd_dbus_interface.h: $(top_srcdir)/src/thd_dbus_interface.xml
 	$(AM_V_GEN) dbus-binding-tool --prefix=thd_dbus_interface --mode=glib-server --output=$@ $<
 
-thd_resources.c: $(top_srcdir)/thermald.gresource.xml
+thermald_resources.c: $(top_srcdir)/thermald-resource.gresource.xml
 	$(AM_V_GEN) glib-compile-resources --generate-source thermald-resource.gresource.xml
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,12 +84,16 @@ thermald_SOURCES = \
 	src/thd_zone_kbl_amdgpu.cpp \
 	src/thd_sensor_rapl_power.cpp \
 	src/thd_zone_rapl_power.cpp \
-	src/thd_gddv.cpp
+	src/thd_gddv.cpp \
+	thermald-resource.c
 
 man5_MANS = man/thermal-conf.xml.5
 man8_MANS = man/thermald.8
 
 thd_dbus_interface.h: $(top_srcdir)/src/thd_dbus_interface.xml
 	$(AM_V_GEN) dbus-binding-tool --prefix=thd_dbus_interface --mode=glib-server --output=$@ $<
+
+thd_resources.c: $(top_srcdir)/thermald.gresource.xml
+	$(AM_V_GEN) glib-compile-resources --generate-source thermald-resource.gresource.xml
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/configure.ac
+++ b/configure.ac
@@ -130,4 +130,10 @@ AC_CONFIG_FILES([Makefile
                  docs/version.xml
                  data/Makefile])
 
+AC_ARG_ENABLE(gdbus,
+              [AS_HELP_STRING([--disable-gdbus],
+                              [Switch DBus backend to glib-dbus. (Default: GDBus)])],
+              [],
+              [AC_DEFINE([GDBUS], [1], [Enable GDBus support])])
+
 AC_OUTPUT

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,7 @@
  * if the thermal-conf.xml defines parameters.
  */
 
+#include <glib.h>
 #include <glib-unix.h>
 #include <syslog.h>
 #include "thermald.h"
@@ -84,6 +85,10 @@ static gboolean ignore_cpuid_check = false;
 gboolean exclusive_control = FALSE;
 
 static GMainLoop *g_main_loop;
+
+#ifdef GDBUS
+gint watcher_id = 0;
+#endif
 
 // g_log handler. All logs will be directed here
 void thd_logger(const gchar *log_domain, GLogLevelFlags log_level,
@@ -370,6 +375,10 @@ int main(int argc, char *argv[]) {
 	thd_log_debug("Start main loop\n");
 	g_main_loop_run(g_main_loop);
 	thd_log_warn("Oops g main loop exit..\n");
+
+#ifdef GDBUS
+	g_bus_unwatch_name (watcher_id);
+#endif
 
 	fprintf(stdout, "Exiting ..\n");
 	clean_up_lockfile();

--- a/src/thd_dbus_interface.cpp
+++ b/src/thd_dbus_interface.cpp
@@ -30,17 +30,20 @@
 #include "thd_zone.h"
 #include "thd_trip_point.h"
 
-typedef struct {
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib/gprintf.h>
+#include <glib-object.h>
+
+struct _PrefObject {
 	GObject parent;
-} PrefObject;
+};
 
-typedef struct {
-	GObjectClass parent;
-} PrefObjectClass;
-
-GType pref_object_get_type(void);
-#define MAX_DBUS_REPLY_STR_LEN	100
 #define PREF_TYPE_OBJECT (pref_object_get_type())
+G_DECLARE_FINAL_TYPE(PrefObject, pref_object, PREF, OBJECT, GObject)
+
+#define MAX_DBUS_REPLY_STR_LEN	100
+
 G_DEFINE_TYPE(PrefObject, pref_object, G_TYPE_OBJECT)
 
 gboolean thd_dbus_interface_terminate(PrefObject *obj, GError **error);

--- a/thermald-resource.gresource.xml
+++ b/thermald-resource.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/freedesktop/thermald">
+    <file preprocess="xml-stripblanks">src/thd_dbus_interface.xml</file>
+  </gresource>
+</gresources>


### PR DESCRIPTION
Hi,

This work migrated the DBus backend to GDBus. Since dbus-glib will be deprecated, the applications depending on it should be migrated to use GDBus as the DBus backend. Notably, the thermald package, shipped by RHEL for its customers, is currently the only package dependent on glib-dbus. This patch migrates the DBus backend to GDBus and it also resolves the dependency issue of the packages. Furthermore, it brings benefits to various Linux distributions affected by the deprecation of dbus-glib.

Fixes: https://github.com/intel/thermal_daemon/issues/348, https://github.com/intel/thermal_daemon/issues/416