### PR TITLE
Fix unable to terminate through Dbus API

### DIFF
--- a/src/thd_dbus_interface.cpp
+++ b/src/thd_dbus_interface.cpp
@@ -131,7 +131,9 @@ gboolean thd_dbus_interface_disable_cooling_device(PrefObject *obj, gchar *name,
 }
 
 // This is a generated file, which expects the above prototypes
+#ifndef GDBUS
 #include "thd_dbus_interface.h"
+#endif
 
 // DBUS Related functions
 
@@ -144,8 +146,10 @@ static void pref_object_init(PrefObject *obj) {
 static void pref_object_class_init(PrefObjectClass *_class) {
 	g_assert(_class != NULL);
 
+#ifndef GDBUS
 	dbus_g_object_type_install_info(PREF_TYPE_OBJECT,
 			&dbus_glib_thd_dbus_interface_object_info);
+#endif
 }
 
 // Callback function called to inform a sent value via dbus

--- a/src/thd_dbus_interface.cpp
+++ b/src/thd_dbus_interface.cpp
@@ -1220,6 +1220,8 @@ int thd_dbus_server_init(gboolean (*exit_handler)(void)) {
 		return THD_FATAL_ERROR;
 	}
 
+	thd_dbus_exit_callback = exit_handler;
+
 	interface_vtable.method_call = thd_dbus_handle_method_call;
 	interface_vtable.get_property = thd_dbus_handle_get_property;
 	interface_vtable.set_property = thd_dbus_handle_set_property;


### PR DESCRIPTION
This patch includes two fixes.

1. Unable to terminate through Dbus API.
2. Skip dbus-glib API when GDbus is used.