### PR TITLE
Downgrade log level on "Unsupported condition"

### DIFF
--- a/src/thd_gddv.cpp
+++ b/src/thd_gddv.cpp
@@ -1123,7 +1123,7 @@ int cthd_gddv::verify_condition(struct condition condition) {
 		cond_name = "UKNKNOWN";
 	else
 		cond_name = condition_names[condition.condition];
-	thd_log_error("Unsupported condition %" PRIu64 " (%s)\n", condition.condition, cond_name);
+	thd_log_info("Unsupported condition %" PRIu64 " (%s)\n", condition.condition, cond_name);
 
 	return THD_ERROR;
 }
@@ -1138,7 +1138,7 @@ int cthd_gddv::verify_conditions() {
 	}
 
 	if (result != 0)
-		thd_log_error("Unsupported conditions are present\n");
+		thd_log_info("Unsupported conditions are present\n");
 
 	return result;
 }


### PR DESCRIPTION
The "Unsupported condition" are quite common on modern Intel CPUs. It's also expected as thermald doesn't have proper support for those conditions (and probably never will).

So lower the log level to make it less scary.