### PR TITLE
Makefile: Fix Failed to open file thermald-resource.gresource.xml

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -95,6 +95,6 @@ thd_dbus_interface.h: $(top_srcdir)/src/thd_dbus_interface.xml
 	$(AM_V_GEN) dbus-binding-tool --prefix=thd_dbus_interface --mode=glib-server --output=$@ $<
 
 thermald-resource.c: $(top_srcdir)/thermald-resource.gresource.xml
-	$(AM_V_GEN) glib-compile-resources --generate-source thermald-resource.gresource.xml
+	$(AM_V_GEN) glib-compile-resources --generate-source --sourcedir=${top_srcdir} $<
 
 CLEANFILES = $(BUILT_SOURCES)


### PR DESCRIPTION
In case build directory is different from source, make sure make is able to find the correct input files.

Fixes:
| dbus-binding-tool --prefix=thd_dbus_interface --mode=glib-server --output=thd_dbus_interface.h ../git/src/thd_dbus_interface.xml | glib-compile-resources --generate-source thermald-resource.gresource.xml | Failed to open file “thermald-resource.gresource.xml”: No such file or directory