### PR TITLE
Fix incorrect integer format specifiers

### DIFF
--- a/src/thd_cdev_rapl.cpp
+++ b/src/thd_cdev_rapl.cpp
@@ -495,12 +495,12 @@ bool cthd_sysfs_cdev_rapl::read_ppcc_power_limits() {
 		}
 
 		if (pl0_max_pwr <= pl0_min_pwr) {
-			thd_log_info("Invalid limits: ppcc limits max:%u min:%u  min_win:%u step:%u\n",
+			thd_log_info("Invalid limits: ppcc limits max:%d min:%d  min_win:%d step:%d\n",
 					pl0_max_pwr, pl0_min_pwr, pl0_min_window, pl0_step_pwr);
 			return false;
 		}
 
-		thd_log_info("ppcc limits max:%u min:%u  min_win:%u step:%u\n",
+		thd_log_info("ppcc limits max:%d min:%d  min_win:%d step:%d\n",
 				pl0_max_pwr, pl0_min_pwr, pl0_min_window, pl0_step_pwr);
 
 		int policy_matched;
@@ -570,12 +570,12 @@ bool cthd_sysfs_cdev_rapl::read_ppcc_power_limits() {
 		int def_max_power;
 
 		if (pl0_max_pwr <= pl0_min_pwr) {
-			thd_log_info("Invalid limits: ppcc limits max:%u min:%u  min_win:%u step:%u\n",
+			thd_log_info("Invalid limits: ppcc limits max:%d min:%d  min_win:%d step:%d\n",
 					pl0_max_pwr, pl0_min_pwr, pl0_min_window, pl0_step_pwr);
 			return false;
 		}
 
-		thd_log_info("ppcc limits max:%u min:%u  min_win:%u step:%u\n",
+		thd_log_info("ppcc limits max:%d min:%d  min_win:%d step:%d\n",
 				pl0_max_pwr, pl0_min_pwr, pl0_min_window, pl0_step_pwr);
 
 		def_max_power = rapl_read_pl1_max();

--- a/src/thd_engine_default.cpp
+++ b/src/thd_engine_default.cpp
@@ -310,7 +310,7 @@ bool cthd_engine_default::add_int340x_processor_dev(void)
 
 				thd_log_info("Processor thermal device is present \n");
 				thd_log_info("It will act as CPU thermal zone !! \n");
-				thd_log_info("Processor thermal device passive Trip is %d\n",
+				thd_log_info("Processor thermal device passive Trip is %u\n",
 						trip->get_trip_temp());
 
 				processor_thermal->set_zone_active();

--- a/src/thd_gddv.cpp
+++ b/src/thd_gddv.cpp
@@ -422,7 +422,7 @@ void cthd_gddv::dump_apct() {
 	for (unsigned int i = 0; i < conditions.size(); ++i) {
 		std::vector<struct condition> condition_set;
 
-		thd_log_info("condition_set %d\n", i);
+		thd_log_info("condition_set %u\n", i);
 		condition_set = conditions[i];
 		for (unsigned int j = 0; j < condition_set.size(); ++j) {
 			std::string cond_name, comp_str, op_str;


### PR DESCRIPTION
There are a handful of incorrect %d or %u format specifiers being used for integer values. Fix this.

Detected using cppcheck static code analysis.