### PR TITLE
Thermal Monitor: Remove deprecated calls

### DIFF
--- a/tools/thermal_monitor/ThermalMonitor.pro
+++ b/tools/thermal_monitor/ThermalMonitor.pro
@@ -14,7 +14,11 @@ CONFIG(release): DEFINES += QT_NO_DEBUG_OUTPUT
 TARGET = ThermalMonitor
 TEMPLATE = app
 
+# Depending on distro and QT version
+# name can be different, so choose correct one for your distro
 LIBS += -lQCustomPlot
+#LIBS += -lqcustomplot
+#LIBS += -lqcustomplot-qt6
 
 SOURCES += main.cpp\
         mainwindow.cpp \

--- a/tools/thermal_monitor/mainwindow.cpp
+++ b/tools/thermal_monitor/mainwindow.cpp
@@ -12,7 +12,7 @@
 */
 
 #include <QMessageBox>
-#include <QDesktopWidget>
+#include <QScreen>
 #include "mainwindow.h"
 #include "pollingdialog.h"
 #include "sensorsdialog.h"
@@ -79,7 +79,7 @@ void MainWindow::setupMenus()
     settingsMenu->addAction("Configure &polling interval", this, SLOT(configurePollingInterval()));
     settingsMenu->addAction("Configure &sensors", this, SLOT(configureSensors()));
     settingsMenu->addAction("&Clear settings and quit", this, SLOT(clearAndExit()));
-    settingsMenu->addAction("&Quit", this, SLOT(close()), QKeySequence::Quit);
+    settingsMenu->addAction("&Quit", this, SLOT(close()));
     QMenu *helpMenu = menuBar()->addMenu("&Help");
     helpMenu->addAction("&About", this, SLOT(showAboutDialog()));
 }
@@ -242,7 +242,7 @@ void MainWindow::updateTemperatureDataSlot()
         }
 
     if(logging_enabled) {
-        outStreamLogging << endl;
+            outStreamLogging << Qt::endl;
     }
 
     m_plotWidget->replot();
@@ -301,8 +301,8 @@ void MainWindow::loadSettings()
         move(settings.value("mainWindowGeometry/pos").toPoint());
     } else {
         // otherwise start with the default geometry calculated from the desktop size
-        QDesktopWidget desktop;
-        QRect screen = desktop.screenGeometry();
+	QScreen *qscreen = QGuiApplication::primaryScreen();
+        QRect screen = qscreen->availableGeometry();
         int width, height, x, y;
 
         width = screen.width() / DEFAULT_SCREEN_SIZE_DIVISOR;
@@ -403,7 +403,7 @@ void MainWindow::changeLogVariables(bool log_enabled, bool log_vis_only,
         QTextStream out(&logging_file);
         if (!logging_file.open(QIODevice::WriteOnly | QIODevice::Text)) {
             qCritical() << "Cannot open file for writing: "
-                        << qPrintable(logging_file.errorString()) << endl;
+                        << qPrintable(logging_file.errorString()) << Qt::endl;
             return;
         }
         outStreamLogging.setDevice(&logging_file);
@@ -414,7 +414,7 @@ void MainWindow::changeLogVariables(bool log_enabled, bool log_vis_only,
                 outStreamLogging << m_plotWidget->graph(i)->name() << ", ";
             }
         }
-        outStreamLogging << endl;
+        outStreamLogging << Qt::endl;
     }
 
     // logging has been turned off, so close the file

--- a/tools/thermal_monitor/tripsdialog.cpp
+++ b/tools/thermal_monitor/tripsdialog.cpp
@@ -124,9 +124,6 @@ void tripsDialog::on_treeWidget_clicked(const QModelIndex &index)
     // Alternate the background color, black to display on the graph, white to ignore
     if (trip != -1 && col == 1){ // if the user clicks on a temperature
         ui->label->setText("Zone: " + index.parent().data().toString());
-        ui->label_2->setText("Type: " +
-                             index.parent().child(trip, col + 1).data().toString()
-                             + " (°C)");
         ui->lineEdit->setText(index.data().toString());
 
         // ACTIVE_TRIP modification not supported at this time


### PR DESCRIPTION
Remove deprecated qt interface. With this it can also build with QT6. But since the library name for libcustomplot is distro dependent, ThermalMonitor.pro, must be updated. Keep one of the line from the following:
LIBS += -lQCustomPlot
LIBS += -lqcustomplot
LIBS += -lqcustomplot-qt6