### PR TITLE
Thermal Monitor: Add trip type back

### DIFF
--- a/tools/thermal_monitor/tripsdialog.cpp
+++ b/tools/thermal_monitor/tripsdialog.cpp
@@ -124,6 +124,11 @@ void tripsDialog::on_treeWidget_clicked(const QModelIndex &index)
     // Alternate the background color, black to display on the graph, white to ignore
     if (trip != -1 && col == 1){ // if the user clicks on a temperature
         ui->label->setText("Zone: " + index.parent().data().toString());
+
+        const QAbstractItemModel *model = index.model();
+        const QModelIndex &child = model->index(trip, col + 1, index.parent());
+
+        ui->label_2->setText("Type: " + child.data().toString() + " (°C)");
         ui->lineEdit->setText(index.data().toString());
 
         // ACTIVE_TRIP modification not supported at this time


### PR DESCRIPTION
When user clicks on trip temperature in the configure trip dialog, It used to display, Zone and trip type. With the commit to remove deprecated warning for QModelIndex::child(int row, int column), the "type" display was removed.

Add back "type" with suggested alternative QAbstractItemModel::index() and display.