### PR TITLE
src: thd_dbus_interface: add extra sanity check on introspection_data

### DIFF
--- a/src/thd_dbus_interface.cpp
+++ b/src/thd_dbus_interface.cpp
@@ -1172,7 +1172,7 @@ thd_dbus_on_bus_acquired(GDBusConnection *connection,
 
 	introspection_data = thd_dbus_load_introspection("src/thd_dbus_interface.xml",
 							 &error);
-	if (error != NULL) {
+	if (introspection_data == NULL || error != NULL) {
 		thd_log_error("Couldn't create introspection data: %s:\n",
 			      error->message);
 		return;


### PR DESCRIPTION
gcc static analyzer warns that introspection_data is not being null checked which could lead to a potential null pointer dereference. Even though error is being checked, it seems prudent to add a null check on introspection_data to make the code more resiliant and also to silence static analysis warnings.