### PR TITLE
Fix resource leak on opened dir descriptor

### DIFF
--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -607,6 +607,7 @@ int cthd_engine_adaptive::set_int3400_base_path()
 					return THD_SUCCESS;
 				}
 			}
+			closedir(dir);
 		}
 	}
 


### PR DESCRIPTION
The opened dir descriptor is not being closed and is causing a resource leak. Close it.

Fixes: 3ea73d5fc460 ("Auto detect int3400 base path")