### PR TITLE
Don't reset clamp bit for MSR RAPL

### DIFF
--- a/src/thd_engine_default.cpp
+++ b/src/thd_engine_default.cpp
@@ -683,8 +683,6 @@ int cthd_engine_default::read_cooling_devices() {
 
 				if (adaptive_mode) {
 					thd_log_info("Disable rapl-msr interface and use rapl-mmio\n");
-					rapl_dev->rapl_update_enable_status(0);
-
 					target.code = "PL1MAX";
 					target.argument = "200000";
 					rapl_dev->set_adaptive_target(target);


### PR DESCRIPTION
Since Linux RAPL driver doesn't have separate enable/disable for clamping RAPL, don't reset RAPL enabled bit. With current enable/disable powercap interface, clamp bit is also reset. This allows power to stay above set power limit in some cases.