### PR TITLE
Use correct format specifier for time_t

### DIFF
--- a/src/thd_gddv.cpp
+++ b/src/thd_gddv.cpp
@@ -455,8 +455,8 @@ void cthd_gddv::dump_apct() {
 
 			thd_log_info(
 					"\ttarget:%d device:%s condition:%s comparison:%s argument:%d"
-							" operation:%s time_comparison:%d time:%ld"
-							" stare:%d state_entry_time:%ld\n",
+							" operation:%s time_comparison:%d time:%jd"
+							" stare:%d state_entry_time:%jd\n",
 					condition_set[j].target, condition_set[j].device.c_str(),
 					cond_name.c_str(), comp_str.c_str(),
 					condition_set[j].argument, op_str.c_str(),


### PR DESCRIPTION
use %jd instead of %ld to print variable of time_t type otherwise on 32 bit system:

src/thd_gddv.cpp:457:41: error: format '%ld' expects argument of type 'long int', but argument 11 has type 'time_t' {aka 'long long int'} [-Werror=format=]
src/thd_gddv.cpp:457:41: error: format '%ld' expects argument of type 'long int', but argument 13 has type 'time_t' {aka 'long long int'} [-Werror=format=]