### PR TITLE
Compile issue on i586 for time_t print

### DIFF
--- a/src/thd_gddv.cpp
+++ b/src/thd_gddv.cpp
@@ -460,8 +460,8 @@ void cthd_gddv::dump_apct() {
 					condition_set[j].target, condition_set[j].device.c_str(),
 					cond_name.c_str(), comp_str.c_str(),
 					condition_set[j].argument, op_str.c_str(),
-					condition_set[j].time_comparison, condition_set[j].time,
-					condition_set[j].state, condition_set[j].state_entry_time);
+					condition_set[j].time_comparison, (intmax_t)condition_set[j].time,
+					condition_set[j].state, (intmax_t)condition_set[j].state_entry_time);
 		}
 	}
 	thd_log_info("..apct dump end..\n");


### PR DESCRIPTION
Refer to issue:
https://github.com/intel/thermal_daemon/issues/488

time_t print with format %jd is a problem. The fix was added for i386 compile but that broke i586.