### PR TITLE
Do not build string when debug logs are disabled

### DIFF
--- a/src/thermald.h
+++ b/src/thermald.h
@@ -77,7 +77,11 @@
 #define thd_log_error		g_critical
 #define thd_log_warn		g_warning
 #define thd_log_msg		g_message
-#define thd_log_debug		g_debug
+#define thd_log_debug(...) \
+	do { \
+		if (G_UNLIKELY (!g_log_writer_default_would_drop (G_LOG_LEVEL_DEBUG, G_LOG_DOMAIN))) \
+			g_debug(__VA_ARGS__); \
+	} while (0)
 #define thd_log_info(...)	g_log(NULL, G_LOG_LEVEL_INFO, __VA_ARGS__)
 #else
 static int dummy_printf(const char *__restrict __format, ...) {


### PR DESCRIPTION
Previously thermald built then discarded log messages, consuming most of its CPU time in tight loops like `cthd_gddv::evaluate_conditions`. This accounted for about an hour of CPU usage over a 16-day period.

Signed-off-by: Andrew Gaul <andrew@gaul.org>