### PR TITLE
Call `csys_fs::read` helpers where possible

### DIFF
--- a/src/thd_cdev_backlight.cpp
+++ b/src/thd_cdev_backlight.cpp
@@ -47,12 +47,9 @@ int cthd_cdev_backlight::update() {
 	int ret;
 
 	if (cdev_sysfs.exists()) {
-		std::string temp_str;
-
-		ret = cdev_sysfs.read("max_brightness", temp_str);
+		ret = cdev_sysfs.read("max_brightness", &max_state);
 		if (ret < 0)
 			return ret;
-		std::istringstream(temp_str) >> max_state;
 	}
 
 	if (max_state <= 0)
@@ -105,15 +102,11 @@ void cthd_cdev_backlight::set_curr_state(int state, int arg) {
 	}
 
 	if (ref_backlight_state == 0 && state == inc_dec_val) {
-		std::string temp_str;
-
 		// First time enter to throttle LCD after normal or state == 0
 		// Store the current backlight
-		ret = cdev_sysfs.read("brightness", temp_str);
+		ret = cdev_sysfs.read("brightness", &ref_backlight_state);
 		if (ret < 0)
 			return;
-
-		std::istringstream(temp_str) >> ref_backlight_state;
 
 		thd_log_debug("LCD ref state is %d\n", ref_backlight_state);
 	}

--- a/src/thd_cdev_cpufreq.cpp
+++ b/src/thd_cdev_cpufreq.cpp
@@ -93,12 +93,10 @@ int cthd_cdev_cpufreq::init() {
 	unsigned int scaling_max_frequency = 0;
 	for (int i = cpu_start_index; i <= cpu_end_index; ++i) {
 		std::stringstream str;
-		std::string freq_str;
+		unsigned int freq_int;
 		str << "cpu" << i << "/cpufreq/scaling_min_freq";
 		if (cdev_sysfs.exists(str.str())) {
-			cdev_sysfs.read(str.str(), freq_str);
-			unsigned int freq_int;
-			std::istringstream(freq_str) >> freq_int;
+			cdev_sysfs.read(str.str(), reinterpret_cast<int*>(&freq_int));
 			if (scaling_min_frequency == 0 || freq_int < scaling_min_frequency)
 				scaling_min_frequency = freq_int;
 		}
@@ -106,13 +104,10 @@ int cthd_cdev_cpufreq::init() {
 
 	for (int i = cpu_start_index; i <= cpu_end_index; ++i) {
 		std::stringstream str;
-		std::string freq_str;
+		unsigned int freq_int;
 		str << "cpu" << i << "/cpufreq/scaling_max_freq";
 		if (cdev_sysfs.exists(str.str())) {
-			cdev_sysfs.read(str.str(), freq_str);
-
-			unsigned int freq_int;
-			std::istringstream(freq_str) >> freq_int;
+			cdev_sysfs.read(str.str(), reinterpret_cast<int*>(&freq_int));
 			if (scaling_max_frequency == 0 || freq_int > scaling_max_frequency)
 				scaling_max_frequency = freq_int;
 		}

--- a/src/thd_cdev_gen_sysfs.cpp
+++ b/src/thd_cdev_gen_sysfs.cpp
@@ -26,9 +26,9 @@
 
 int cthd_gen_sysfs_cdev::update() {
 	if (cdev_sysfs.exists()) {
-		std::string state_str;
-		cdev_sysfs.read("", state_str);
-		std::istringstream(state_str) >> curr_state;
+		int ret = cdev_sysfs.read("", &curr_state);
+		if (ret < 0)
+			return ret;
 		min_state = max_state = curr_state;
 	} else {
 		if (cdev_sysfs.get_base_path() && !strcmp(cdev_sysfs.get_base_path(), ""))

--- a/src/thd_cdev_intel_pstate_driver.cpp
+++ b/src/thd_cdev_intel_pstate_driver.cpp
@@ -111,9 +111,9 @@ int cthd_intel_p_state_cdev::update() {
 
 	tc_state_dev << "/max_perf_pct";
 	if (cdev_sysfs.exists(tc_state_dev.str())) {
-		std::string state_str;
-		cdev_sysfs.read(tc_state_dev.str(), state_str);
-		std::istringstream(state_str) >> curr_state;
+		int ret = cdev_sysfs.read(tc_state_dev.str(), &curr_state);
+		if (ret < 0)
+			return ret;
 	} else {
 		return THD_ERROR;
 	}

--- a/src/thd_cdev_therm_sys_fs.cpp
+++ b/src/thd_cdev_therm_sys_fs.cpp
@@ -35,18 +35,18 @@ int cthd_sysfs_cdev::update() {
 	std::stringstream tc_state_dev;
 	tc_state_dev << "cooling_device" << index << "/cur_state";
 	if (cdev_sysfs.exists(tc_state_dev.str())) {
-		std::string state_str;
-		cdev_sysfs.read(tc_state_dev.str(), state_str);
-		std::istringstream(state_str) >> curr_state;
+		int ret = cdev_sysfs.read(tc_state_dev.str(), &curr_state);
+		if (ret < 0)
+			return ret;
 	} else
 		curr_state = 0;
 
 	std::stringstream tc_max_state_dev;
 	tc_max_state_dev << "cooling_device" << index << "/max_state";
 	if (cdev_sysfs.exists(tc_max_state_dev.str())) {
-		std::string state_str;
-		cdev_sysfs.read(tc_max_state_dev.str(), state_str);
-		std::istringstream(state_str) >> max_state;
+		int ret = cdev_sysfs.read(tc_max_state_dev.str(), &max_state);
+		if (ret < 0)
+			return ret;
 	} else
 		max_state = 0;
 
@@ -74,9 +74,9 @@ int cthd_sysfs_cdev::get_max_state() {
 	std::stringstream tc_state_dev;
 	tc_state_dev << "cooling_device" << index << "/max_state";
 	if (cdev_sysfs.exists(tc_state_dev.str())) {
-		std::string state_str;
-		cdev_sysfs.read(tc_state_dev.str(), state_str);
-		std::istringstream(state_str) >> max_state;
+		int ret = cdev_sysfs.read(tc_state_dev.str(), &max_state);
+		if (ret < 0)
+			return ret;
 	} else
 		max_state = 0;
 
@@ -105,9 +105,9 @@ int cthd_sysfs_cdev::get_curr_state() {
 	std::stringstream tc_state_dev;
 	tc_state_dev << "cooling_device" << index << "/cur_state";
 	if (cdev_sysfs.exists(tc_state_dev.str())) {
-		std::string state_str;
-		cdev_sysfs.read(tc_state_dev.str(), state_str);
-		std::istringstream(state_str) >> curr_state;
+		int ret = cdev_sysfs.read(tc_state_dev.str(), &curr_state);
+		if (ret < 0)
+			return ret;
 	} else
 		curr_state = 0;
 

--- a/src/thd_gddv.cpp
+++ b/src/thd_gddv.cpp
@@ -1226,12 +1226,11 @@ int cthd_gddv::evaluate_oem_condition(struct condition condition) {
 
 	if (oem_condition != -1) {
 		std::string filename = "odvp" + std::to_string(oem_condition);
-		std::string data;
-		if (sysfs.read(filename, data) < 0) {
+		int value;
+		if (sysfs.read(filename, &value) < 0) {
 			thd_log_error("Unable to read %s\n", filename.c_str());
 			return THD_ERROR;
 		}
-		int value = std::stoi(data, NULL);
 
 		return compare_condition(std::move(condition), value);
 	}
@@ -1347,15 +1346,15 @@ int cthd_gddv::evaluate_power_slider_condition(
  * */
 int cthd_gddv::evaluate_ac_condition(struct condition condition) {
         csys_fs cdev_sysfs("/sys/class/power_supply/AC/online");
-        std::string buffer;
         int status = 0;
         int value = 0;
 
         thd_log_debug("evaluate evaluate_ac_condition %" PRIu64 "\n", condition.condition);
         if (cdev_sysfs.exists("")) {
-                        cdev_sysfs.read("", buffer);
-                        std::istringstream(buffer) >> status;
-        thd_log_debug("evaluate found battery sys status=%d\n",status);
+                int ret = cdev_sysfs.read("", &status);
+                if (ret < 0)
+                    return ret;
+                thd_log_debug("evaluate found battery sys status=%d\n",status);
         }
         if (status!=1) {
                 value = 1;

--- a/src/thd_rapl_power_meter.cpp
+++ b/src/thd_rapl_power_meter.cpp
@@ -145,25 +145,25 @@ bool cthd_rapl_power_meter::rapl_energy_loop() {
 	if ((curr_time - last_time) <= 0)
 		return true;
 	for (unsigned int i = 0; i < domain_list.size(); ++i) {
-		std::string buffer;
+		unsigned long energy_uj;
 		std::string path;
 
 		if (!domain_list[i].max_energy_range) {
 			std::string _path;
-			std::string _buffer;
+			unsigned long _value;
 			_path = domain_list[i].path + "/" + "max_energy_range_uj";
-			status = sys_fs.read(_path, _buffer);
+			status = sys_fs.read(_path, &_value);
 			if (status >= 0)
-				domain_list[i].max_energy_range = atoll(_buffer.c_str()) / 1000;
+				domain_list[i].max_energy_range = _value / 1000;
 			domain_list[i].max_energy_range_threshold =
 					domain_list[i].max_energy_range / 2;
 		}
 
 		path = domain_list[i].path + "/" + "energy_uj";
-		status = sys_fs.read(path, buffer);
+		status = sys_fs.read(path, &energy_uj);
 		if (status >= 0) {
 			counter = domain_list[i].energy_counter;
-			domain_list[i].energy_counter = atoll(buffer.c_str()) / 1000; // To milli Js
+			domain_list[i].energy_counter = energy_uj / 1000; // To milli Js
 
 			diff = 0;
 			if (domain_list[i].half_way
@@ -259,7 +259,6 @@ unsigned int cthd_rapl_power_meter::rapl_action_get_max_power(
 		if (type == domain_list[i].type) {
 			int status;
 			std::string _path;
-			std::string _buffer;
 			csys_fs sys_fs;
 			int max_power;
 			unsigned int const_0_val = 0, const_1_val = 0;
@@ -267,17 +266,15 @@ unsigned int cthd_rapl_power_meter::rapl_action_get_max_power(
 			const_0_val = 0;
 			const_1_val = 0;
 			_path = domain_list[i].path + "/" + "constraint_0_max_power_uw";
-			status = sys_fs.read(_path, _buffer);
+			status = sys_fs.read(_path, &max_power);
 			if (status >= 0) {
-				max_power = atoi(_buffer.c_str());
 				if (max_power > 0)
 					const_0_val = max_power;
 			}
 
 			_path = domain_list[i].path + "/" + "constraint_1_max_power_uw";
-			status = sys_fs.read(_path, _buffer);
+			status = sys_fs.read(_path, &max_power);
 			if (status >= 0) {
-				max_power = atoi(_buffer.c_str());
 				if (max_power > 0)
 					const_1_val = max_power;
 			}

--- a/src/thd_sensor.cpp
+++ b/src/thd_sensor.cpp
@@ -63,15 +63,13 @@ int cthd_sensor::sensor_update() {
 
 unsigned int cthd_sensor::read_temperature() {
 	csys_fs sysfs;
-	std::string buffer;
 	int temp;
 
 	thd_log_debug("read_temperature sensor ID %d\n", index);
 	if (type == SENSOR_TYPE_THERMAL_SYSFS)
-		sensor_sysfs.read("temp", buffer);
+		sensor_sysfs.read("temp", &temp);
 	else
-		sensor_sysfs.read("", buffer);
-	std::istringstream(buffer) >> temp;
+		sensor_sysfs.read("", &temp);
 	if (temp < 0)
 		temp = 0;
 	thd_log_debug("Sensor %s :temp %u\n", type_str.c_str(), temp);

--- a/src/thd_zone_cpu.cpp
+++ b/src/thd_zone_cpu.cpp
@@ -66,9 +66,9 @@ int cthd_zone_cpu::init() {
 		temp_max_str << "temp" << i << "_max";
 
 		if (dts_sysfs.exists(temp_crit_str.str())) {
-			std::string temp_str;
-			dts_sysfs.read(temp_crit_str.str(), temp_str);
-			std::istringstream(temp_str) >> temp;
+			int ret = dts_sysfs.read(temp_crit_str.str(), &temp);
+			if (ret < 0)
+				return ret;
 			if (critical_temp == 0 || temp < critical_temp)
 				critical_temp = temp;
 
@@ -79,9 +79,9 @@ int cthd_zone_cpu::init() {
 			// Set which index is present
 			sensor_mask = sensor_mask | (1 << i);
 
-			std::string temp_str;
-			dts_sysfs.read(temp_max_str.str(), temp_str);
-			std::istringstream(temp_str) >> temp;
+			int ret = dts_sysfs.read(temp_max_str.str(), &temp);
+			if (ret < 0)
+				return ret;
 			if (max_temp == 0 || temp < max_temp)
 				max_temp = temp;
 			found = true;


### PR DESCRIPTION
Returning integers avoids unnecessary `std::string` allocations.  Also add missing error-handling.

Signed-off-by: Andrew Gaul <andrew@gaul.org>