### PR TITLE
Return `std::string` by const ref instead of value

### DIFF
--- a/src/thd_cdev.h
+++ b/src/thd_cdev.h
@@ -236,7 +236,7 @@ public:
 	std::string get_cdev_alias() {
 		return alias_str;
 	}
-	std::string get_base_path() {
+	const std::string& get_base_path() {
 		return cdev_sysfs.get_base_path();
 	}
 	void set_cdev_type(std::string _type_str) {

--- a/src/thd_cdev_gen_sysfs.cpp
+++ b/src/thd_cdev_gen_sysfs.cpp
@@ -31,7 +31,7 @@ int cthd_gen_sysfs_cdev::update() {
 		std::istringstream(state_str) >> curr_state;
 		min_state = max_state = curr_state;
 	} else {
-		if (cdev_sysfs.get_base_path() && !strcmp(cdev_sysfs.get_base_path(), ""))
+		if (cdev_sysfs.get_base_path().empty())
 			return THD_ERROR;
 
 		int ret = cdev_sysfs.create();

--- a/src/thd_rapl_power_meter.cpp
+++ b/src/thd_rapl_power_meter.cpp
@@ -49,7 +49,7 @@ cthd_rapl_power_meter::cthd_rapl_power_meter(unsigned int mask) :
 		thd_log_debug("RAPL sysfs present\n");
 		rapl_present = true;
 		last_time = time(NULL);
-		rapl_read_domains(rapl_sysfs.get_base_path());
+		rapl_read_domains(rapl_sysfs.get_base_path().c_str());
 	} else {
 		thd_log_warn("NO RAPL sysfs present\n");
 		rapl_present = false;
@@ -117,7 +117,7 @@ void cthd_rapl_power_meter::rapl_read_domains(const char *dir_name) {
 			closedir(dir);
 		} else {
 			thd_log_debug("opendir failed %s :%s\n", strerror(errno),
-					rapl_sysfs.get_base_path());
+					rapl_sysfs.get_base_path().c_str());
 		}
 	}
 

--- a/src/thd_sensor.cpp
+++ b/src/thd_sensor.cpp
@@ -54,7 +54,7 @@ int cthd_sensor::sensor_update() {
 			return THD_SUCCESS;
 		} else {
 			thd_log_msg("sensor id %d %s: No temp sysfs for reading raw temp\n",
-					index, sensor_sysfs.get_base_path());
+					index, sensor_sysfs.get_base_path().c_str());
 			return THD_ERROR;
 		}
 	}

--- a/src/thd_sensor.h
+++ b/src/thd_sensor.h
@@ -54,11 +54,11 @@ public:
 	virtual ~cthd_sensor() {
 	}
 	int sensor_update();
-	virtual std::string get_sensor_type() {
+	virtual const std::string& get_sensor_type() {
 		return type_str;
 	}
 
-	virtual std::string get_sensor_path() {
+	virtual const std::string& get_sensor_path() {
 		return sensor_sysfs.get_base_path();
 	}
 
@@ -82,7 +82,7 @@ public:
 	}
 	virtual void sensor_dump() {
 		thd_log_info("sensor index:%d %s %s Async:%d\n", index,
-				type_str.c_str(), sensor_sysfs.get_base_path(), async_capable);
+				type_str.c_str(), sensor_sysfs.get_base_path().c_str(), async_capable);
 	}
 	// Even if sensors are capable of async, it is possible that it is not reliable enough
 	// at critical monitoring point. Sensors can be forced to go to poll mode at that temp

--- a/src/thd_sys_fs.h
+++ b/src/thd_sys_fs.h
@@ -62,8 +62,8 @@ public:
 	int read(const std::string &path, unsigned int position, char *buf,
 			int len);
 
-	const char *get_base_path() {
-		return base_path.c_str();
+	const std::string& get_base_path() {
+		return base_path;
 	}
 	int read_symbolic_link_value(const std::string &path, char *buf, int len);
 


### PR DESCRIPTION
This avoids extra allocations and copies.

Signed-off-by: Andrew Gaul <andrew@gaul.org>