### PR TITLE
Fix return without unlocking thd_engine_mutex

### DIFF
--- a/src/thd_engine.cpp
+++ b/src/thd_engine.cpp
@@ -1010,10 +1010,8 @@ void cthd_engine::check_for_rt_kernel() {
 }
 
 int cthd_engine::user_add_sensor(std::string name, std::string path) {
-	pthread_mutex_lock(&thd_engine_mutex);
-
 	if (path.empty())
-		return THD_ERROR;
+		pthread_mutex_unlock(&thd_engine_mutex);
 
 	std::string start("/sys/");
 	if (path.substr(0, start.length()) != start) {
@@ -1021,6 +1019,7 @@ int cthd_engine::user_add_sensor(std::string name, std::string path) {
 		return THD_ERROR;
 	}
 
+	pthread_mutex_lock(&thd_engine_mutex);
 	for (unsigned int i = 0; i < sensors.size(); ++i) {
 		if (sensors[i]->get_sensor_type() == name) {
 			cthd_sensor *sensor = sensors[i].get();


### PR DESCRIPTION
A recent set of checks on path don't unlock thd_engine_mutex on error return exits from cthd_engine::user_add_senso leading to locking issues.

Fix this by performing the lock on thd_engine_mutex after the sanity checks on path to avoid the locking issue and to defer locking to the latest point where it is required.

Fixes: d74be68511d55 ("Check for start path instead of anywhere")