### PR TITLE
Case-insensitively compare with CoolingDeviceOrder

### DIFF
--- a/src/thd_cdev_order_parser.cpp
+++ b/src/thd_cdev_order_parser.cpp
@@ -87,7 +87,7 @@ int cthd_cdev_order_parse::parse(xmlNode * a_node, xmlDoc *doc) {
 
 	for (cur_node = a_node; cur_node; cur_node = cur_node->next) {
 		if (cur_node->type == XML_ELEMENT_NODE) {
-			if (!thd_strcmp_n((const char*) cur_node->name, "CoolingDeviceOrder")) {
+			if (!thd_strcasecmp_n((const char*) cur_node->name, "CoolingDeviceOrder")) {
 				parse_new_cdev(cur_node->children, doc);
 			}
 		}


### PR DESCRIPTION
Matches other XML compares.  Found via Claude.