### PR TITLE
Exit for non mobile platforms

### DIFF
--- a/src/thd_engine.cpp
+++ b/src/thd_engine.cpp
@@ -235,8 +235,30 @@ void cthd_engine::enable_power_floor_event()
 	++current_zone_index;
 }
 
+int cthd_engine::check_acpi_platform_profile() {
+	// Check PM profile and fail to start for non mobile platforms
+	csys_fs pm_profile_fs("/sys/firmware/acpi/pm_profile");
+	if (pm_profile_fs.exists()) {
+		std::string pm_profile;
+		pm_profile_fs.read("", pm_profile);
+		thd_log_info("PM profile is %s\n", pm_profile.c_str());
+		if (pm_profile != "2" && pm_profile != "8") {
+			thd_log_error("Non mobile platform, exiting..\n");
+			return THD_FATAL_ERROR;
+		}
+	} else {
+		thd_log_info("PM profile is not available, skipping check\n");
+	}
+
+	return THD_SUCCESS;
+}
+
 int cthd_engine::thd_engine_init(bool ignore_cpuid_check, bool adaptive) {
 	int ret;
+
+	if (check_acpi_platform_profile() != THD_SUCCESS) {
+		return THD_FATAL_ERROR;
+	}
 
 	adaptive_mode = adaptive;
 

--- a/src/thd_engine.h
+++ b/src/thd_engine.h
@@ -143,6 +143,7 @@ public:
 	control_mode_t get_control_mode() {
 		return control_mode;
 	}
+
 	void thd_engine_thread();
 	virtual int thd_engine_init(bool ignore_cpuid_check, bool adaptive = false);
 	virtual int thd_engine_start();
@@ -296,6 +297,8 @@ public:
 	int parser_init();
 	void parser_deinit();
 	int debug_mode_on(void);
+
+	int check_acpi_platform_profile();
 };
 
 #endif /* THD_ENGINE_H_ */

--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -625,6 +625,10 @@ int cthd_engine_adaptive::thd_engine_init(bool ignore_cpuid_check,
 	size_t size;
 	int res;
 
+	if (check_acpi_platform_profile() != THD_SUCCESS) {
+			return THD_FATAL_ERROR;
+	}
+
 	parser_disabled = true;
 	force_mmio_rapl = true;
 

--- a/src/thd_engine_default.cpp
+++ b/src/thd_engine_default.cpp
@@ -833,6 +833,8 @@ int thd_engine_create_default_engine(bool ignore_cpuid_check,
 			thd_log_error("THD engine init failed\n");
 		else
 			thd_log_msg("THD engine init failed\n");
+
+		return res;
 	}
 
 	res = thd_engine->thd_engine_start();


### PR DESCRIPTION
Some recent CPU models are common across mobiles and desktops. Desktop models has some bad ACPI thermal data causing throttling issues. So, check for ACPI PM profile and exit for non mobile platforms.