### PR TITLE
Added NovaLake U/P/H/Hx CPU ID

### DIFF
--- a/src/thd_platform_intel.cpp
+++ b/src/thd_platform_intel.cpp
@@ -80,7 +80,8 @@ static supported_ids_t intel_id_table[] = {
     { 6, 0xc5 }, // Arrow Lake H
     { 6, 0xb5 }, // Arrow Lake U
     { 6, 0xcc }, // Panther Lake L
-    { 15, 0x01 }, // Nova Lake
+    { 15, 0x01 }, // Nova Lake S
+    { 15, 0x03 }, // Nova Lake U/P/H/Hx
     { 0, 0 } // Last Invalid entry
 };
 


### PR DESCRIPTION
Added NVL U/P/H/Hx to the supported platform list. NVL U/P/H/Hx cpu id is different from NVL-S cpu id.