### PR TITLE
adaptive: Stop mapping SwOem conditions to ODVP variables

### DIFF
--- a/src/thd_gddv.cpp
+++ b/src/thd_gddv.cpp
@@ -1358,8 +1358,8 @@ int cthd_gddv::verify_condition(const struct condition& condition) {
 
 	if (condition.condition >= Oem0 && condition.condition <= Oem5)
 		return 0;
-	if (condition.condition >= adaptive_condition(0x1000)
-			&& condition.condition < adaptive_condition(0x10000))
+	if (condition.condition >= adaptive_condition(OEM_CONDITION_BASE_ID)
+			&& condition.condition < adaptive_condition(SW_OEM_CONDITION_BASE_ID))
 		return 0;
 	if (condition.condition == Default)
 		return 0;
@@ -1382,6 +1382,26 @@ int cthd_gddv::verify_condition(const struct condition& condition) {
 		return 0;
 	if (condition.condition == OS_type)
 		return 0;
+
+	/*
+	 * Software-OEM conditions are set at runtime by OEM software through
+	 * the DPTF/ESIF interface, which has no equivalent on Linux, so they
+	 * can never be satisfied here. Don't fail verify_conditions() for
+	 * them: that would change engine startup behavior (unsupported
+	 * condition fallback). They are simply excluded from the ODVP
+	 * mapping, so evaluation fails quietly and the containing condition
+	 * set never matches - the same outcome as when they were misread as
+	 * ODVP variables, without the per-poll odvpN read errors.
+	 */
+	if (condition.condition >= adaptive_condition(SW_OEM_CONDITION_BASE_ID)
+			&& condition.condition < adaptive_condition(PARTICIPANT_CONDITION_BASE_ID)) {
+		thd_log_info(
+				"Software-OEM condition %" PRIu64
+				" (SwOem%" PRIu64 ") is set by OEM software via DPTF, not available on Linux; the condition set using it will never match\n",
+				condition.condition,
+				condition.condition - SW_OEM_CONDITION_BASE_ID);
+		return 0;
+	}
 
 	if ( condition.condition >=  ARRAY_SIZE(condition_names))
 		cond_name = "UNKNOWN";
@@ -1500,9 +1520,9 @@ int cthd_gddv::evaluate_oem_condition(const struct condition& condition) {
 
 	if (condition.condition >= Oem0 && condition.condition <= Oem5)
 		oem_condition = (int) condition.condition - Oem0;
-	else if (condition.condition >= (adaptive_condition) 0x1000
-			&& condition.condition < (adaptive_condition) 0x10000)
-		oem_condition = (int) condition.condition - 0x1000 + 6;
+	else if (condition.condition >= (adaptive_condition) OEM_CONDITION_BASE_ID
+			&& condition.condition < (adaptive_condition) SW_OEM_CONDITION_BASE_ID)
+		oem_condition = (int) condition.condition - OEM_CONDITION_BASE_ID + 6;
 
 	if (oem_condition != -1) {
 		std::string filename = "odvp" + std::to_string(oem_condition);
@@ -1673,8 +1693,8 @@ int cthd_gddv::evaluate_condition(struct condition& condition) {
 	}
 
 	if ((condition.condition >= Oem0 && condition.condition <= Oem5)
-			|| (condition.condition >= (adaptive_condition) 0x1000
-					&& condition.condition < (adaptive_condition) 0x10000))
+			|| (condition.condition >= (adaptive_condition) OEM_CONDITION_BASE_ID
+					&& condition.condition < (adaptive_condition) SW_OEM_CONDITION_BASE_ID))
 		ret = evaluate_oem_condition(condition);
 
 	if (condition.condition == Temperature

--- a/src/thd_gddv.h
+++ b/src/thd_gddv.h
@@ -100,6 +100,21 @@ enum adaptive_condition : uint32_t { // NOLINT(performance-enum-size)
 	OS_type = 86
 };
 
+/*
+ * Adaptive condition ID ranges, matching Intel DPTF's ConditionType
+ * (OemConditionBaseId / SwOemConditionBaseId / ParticipantConditionBaseId).
+ *
+ * [OEM_CONDITION_BASE_ID, SW_OEM_CONDITION_BASE_ID)
+ *     OEM variables exported by the firmware as odvpN sysfs entries.
+ * [SW_OEM_CONDITION_BASE_ID, PARTICIPANT_CONDITION_BASE_ID)
+ *     Software-OEM conditions set at runtime by OEM software through the
+ *     DPTF/ESIF interface. These have no equivalent on Linux, so thermald
+ *     never matches them instead of misreading them as ODVP variables.
+ */
+#define OEM_CONDITION_BASE_ID		0x1000
+#define SW_OEM_CONDITION_BASE_ID	0x2000
+#define PARTICIPANT_CONDITION_BASE_ID	0x10000
+
 enum adaptive_comparison : uint8_t {
 	ADAPTIVE_EQUAL = 0x01, ADAPTIVE_LESSER_OR_EQUAL, ADAPTIVE_GREATER_OR_EQUAL, ADAPTIVE_NOT_EQUAL,
 };


### PR DESCRIPTION
Per Intel DPTF ConditionType.h, condition ids in [0x2000, 0x10000) are
software-OEM conditions set at runtime by OEM software via DPTF/ESIF;
they have no equivalent on Linux. thermald instead lumped the whole
[0x1000, 0x10000) range into ODVP and mapped e.g. 0x200D to a
non-existent odvp4115, logging "Unable to read odvp4115" every poll.

Restrict the ODVP mapping to [0x1000, 0x2000). SwOem conditions are
still recognized by verify_condition() so engine startup behavior is
unchanged (failing verify_conditions() would enter the unsupported
condition fallback and stop evaluating conditions at poll time), but
they are no longer evaluated via ODVP: the containing condition set
quietly never matches, exactly as before when the odvpN read failed,
just without the per-poll error spam. A one-time info message is
logged at startup instead.

No functional change - such sets were never satisfiable on Linux.