### PR TITLE
docs: add AMD Ryzen/k10temp example to thermal-conf.xml(5) manpage

### DIFF
--- a/man/thermal-conf.xml.5
+++ b/man/thermal-conf.xml.5
@@ -519,3 +519,73 @@ Example 7: Use RAPL power limits to control.
 </Platform>
 </ThermalConfiguration>
 .EE
+.PP
+.B Example 8:
+AMD Ryzen / k10temp configuration. On AMD platforms, the CPU temperature
+sensor (k10temp) is exposed via hwmon sysfs but does not have an
+associated thermal_zone in /sys/class/thermal. This means thermald
+cannot auto-discover it and the default CPU DTS monitoring will report
+"No coretemp sysfs found" and "No Zones present". A custom sensor must
+be defined with the hwmon path, and the CPU ID check must be bypassed
+using the \fB--ignore-cpuid-check\fP command line option.
+.PP
+To find the correct hwmon path, run:
+.RS 4
+.EX
+find /sys/class/hwmon/ -exec echo -n "{}: " \e; -exec cat {}/name \e;
+.EE
+.RE
+.PP
+Then identify the k10temp entry and its Tctl sensor. For example, if
+k10temp is hwmon2, the Tctl path is
+/sys/class/hwmon/hwmon2/temp1_input.
+.sp 1
+.EX
+<?xml version="1.0"?>
+<ThermalConfiguration>
+  <Platform>
+    <Name>AMD Ryzen (k10temp via hwmon)</Name>
+    <UUID>*</UUID>
+    <ProductName>*</ProductName>
+    <Preference>QUIET</Preference>
+    <ThermalSensors>
+      <ThermalSensor>
+        <!-- Define a custom sensor name and point it at the
+             k10temp hwmon path. The name must NOT match any
+             auto-discovered hwmon driver name (do not use
+             "k10temp" here); use a unique name instead. -->
+        <Type>amd_cpu_temp</Type>
+        <Path>/sys/class/hwmon/hwmon2/temp1_input</Path>
+        <AsyncCapable>0</AsyncCapable>
+      </ThermalSensor>
+    </ThermalSensors>
+    <ThermalZones>
+      <ThermalZone>
+        <Type>cpu</Type>
+        <TripPoints>
+          <TripPoint>
+            <SensorType>amd_cpu_temp</SensorType>
+            <Temperature>85000</Temperature>
+            <type>passive</type>
+            <CoolingDevice>
+              <type>cpufreq</type>
+              <influence>100</influence>
+              <SamplingPeriod>1</SamplingPeriod>
+            </CoolingDevice>
+          </TripPoint>
+          <TripPoint>
+            <SensorType>amd_cpu_temp</SensorType>
+            <Temperature>95000</Temperature>
+            <type>passive</type>
+            <CoolingDevice>
+              <type>cpufreq</type>
+              <influence>100</influence>
+              <SamplingPeriod>1</SamplingPeriod>
+            </CoolingDevice>
+          </TripPoint>
+        </TripPoints>
+      </ThermalZone>
+    </ThermalZones>
+  </Platform>
+</ThermalConfiguration>
+.EE


### PR DESCRIPTION
## Problem

AMD platforms expose CPU temperature via the `k10temp` hwmon driver but do not have an associated `thermal_zone` in `/sys/class/thermal`. This means thermald cannot auto-discover the sensor, producing:

```
thermal DTS: No coretemp sysfs found
Thermal DTS or hwmon: No Zones present Need to configure manually
```

Users then try to write a `thermal-conf.xml` but hit a second problem: existing documentation and popular blog posts show incorrect XML tag structures for thermald 2.5.x. The result is:

```
XML zone: invalid sensor type k10temp
Zone update failed: unable to bind
```

## Root Cause

The manpage FILE FORMAT section (lines 87-186) correctly shows `<ThermalSensors><ThermalSensor>`, but:

1. **No example demonstrates it.** Examples 1-7 all assume Intel `coretemp` or pre-existing sysfs sensors. None shows how to define a custom hwmon sensor.
2. **Popular references are outdated.** The top search result ([Colin King's 2015 blog post](http://smackerelofopinion.blogspot.com/2015/09/tweaking-thermald-configuration-file.html)) uses `<Name>` and `<Sensor>`, but thermald 2.5.x parses `<Type>` inside `<ThermalSensor>` (see `thd_parse.cpp:parse_new_sensor`).
3. **Sensor name conflicts.** Using the hwmon driver name (e.g. `k10temp`) as the `<Type>` causes a silent conflict — the sensor is never registered. A unique name is required.

## Fix

Add **Example 8** to the manpage — a complete, working AMD Ryzen configuration that:

- Defines a custom sensor via `<ThermalSensors><ThermalSensor>` with the correct `<Type>`, `<Path>`, and `<AsyncCapable>` tags
- Points at the k10temp hwmon path (`/sys/class/hwmon/hwmon2/temp1_input`)
- Uses a unique sensor name (`amd_cpu_temp`) to avoid conflicts
- Notes the `--ignore-cpuid-check` requirement for AMD CPUs

## Verification

Tested on AMD Ryzen 9 5950X (ASUS B550-E) with thermald 2.5.11:

```
sensor index:1 amd_cpu_temp /sys/class/hwmon/hwmon2/temp1_input Async:0
 Zone 0
   Trip Point 0: 85C passive -> cpufreq throttle
   Trip Point 1: 95C passive -> cpufreq throttle
```

Also verified: groff syntax (no warnings), XML well-formedness (all 8 blocks parse), minimal diff (+70 lines, single file, additions only).

Tag names confirmed against source code (`src/thd_parse.cpp`, `parse_new_sensor()` and `parse_thermal_sensors()` functions at tag v2.5.11).