### PR TITLE
optional gtkdocsize

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,11 @@
 include $(GLIB_MAKEFILE)
 
-SUBDIRS = . docs data
+if ENABLE_DOC
+DOC_SUBDIR = docs
+endif
+
+SUBDIRS = . $(DOC_SUBDIR) data
+DIST_SUBDIRS = . docs data
 
 ACLOCAL_AMFLAGS =
 

--- a/README.txt
+++ b/README.txt
@@ -29,6 +29,8 @@ Install
 	yum install upower-devel
 	yum install libevdev-devel
 
+Note: gtk-doc is only required when building documentation with --enable-doc.
+
 Replace yum with dnf for later Fedora versions.
 
 2
@@ -70,6 +72,8 @@ Building on Ubuntu
 	sudo apt install libupower-glib-dev
 	sudo apt install libevdev-dev
 
+Note: gtk-doc-tools is only required when building documentation with --enable-doc.
+
 2
 Build
 
@@ -100,6 +104,8 @@ Install
 	zypper in gtk-doc
 	zypper in libupower-glib-devel
 	zypper in libevdev-devel
+
+gtk-doc is only required when building documentation with --enable-doc.
 
 For build, follow the same procedure as Fedora.
 
@@ -134,6 +140,9 @@ through a shared open_validated_xml_file() path.
 APCT/IDSP/data vault), max limits for zones/cooling devices/segments/conditions,
 fixed lock/unlock and stale mutex issues, guarded container operations, and
 improved exception safety (e.g., unique_ptr use for virtual sensor links).
+
+- Build system update: added an opt-in --enable-doc configure option so gtk-doc
+is only required when documentation generation is explicitly enabled.
 
 Release 2.5.11
 - Clang-tidy fixes

--- a/autogen.sh
+++ b/autogen.sh
@@ -4,10 +4,24 @@ srcdir=`dirname $0`
 test -z "$srcdir" && srcdir=.
 olddir=`pwd`
 
+enable_doc=no
+for arg in "$@"; do
+    case "$arg" in
+        --enable-doc|--enable-doc=yes|--enable-gtk-doc|--enable-gtk-doc=yes)
+            enable_doc=yes
+            ;;
+    esac
+done
+
 cd "$srcdir"
 
 aclocal --install || exit 1
-gtkdocize --copy --flavour no-tmpl || exit 1
+if test "x$enable_doc" = "xyes"; then
+    echo "autogen.sh: gtk-doc enabled; running gtkdocize"
+    gtkdocize --copy --flavour no-tmpl || exit 1
+else
+    echo "autogen.sh: gtk-doc disabled; skipping gtkdocize"
+fi
 autoreconf --install --verbose || exit 1
 
 cd "$olddir"

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,18 @@ AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([1.11 foreign no-define subdir-objects])
 AM_MAINTAINER_MODE([enable])
 
+AC_ARG_ENABLE([doc],
+              [AS_HELP_STRING([--enable-doc],
+                              [Build documentation using gtk-doc (default: no)])],
+              [],
+              [enable_doc=no])
+
 GTK_DOC_CHECK([1.11],[--flavour no-tmpl])
+AS_IF([test "x$enable_doc" = "xyes" -a "x$have_gtk_doc" = "xno"],
+            [AC_MSG_ERROR([
+    You must have gtk-doc installed to build documentation.
+    Please install gtk-doc or configure with '--disable-doc'.])])
+AM_CONDITIONAL([ENABLE_DOC], [test "x$enable_doc" = "xyes"])
 
 AC_ARG_WITH(dbus-sys-dir, AS_HELP_STRING([--with-dbus-sys-dir=DIR], [where D-BUS system.d directory is]))
 if test -n "$with_dbus_sys_dir" ; then
@@ -48,6 +59,7 @@ echo "  systemdunitdir: $with_systemdsystemunitdir"
 echo "  tdbinary: $tdbinary"
 echo "  tdconfdir: $tdconfdir"
 echo "  tdrundir: $tdrundir"
+echo "  build-doc: $enable_doc"
 echo
 
 GETTEXT_PACKAGE=thermald

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -48,6 +48,10 @@ MAINTAINERCLEANFILES =		\
 
 include $(top_srcdir)/gtk-doc.make
 
+if ENABLE_DOC
+all-local: all-gtk-doc
+endif
+
 EXTRA_DIST = thermal_daemon-docs.xml
 
 CLEANFILES +=				\


### PR DESCRIPTION
By default gtkdoc dependency is not there unless called with autogen.sh --enable-doc.

Issue #407