### PR TITLE
thd_gddv: fix building on 32-bit systems

### DIFF
--- a/src/thd_gddv.cpp
+++ b/src/thd_gddv.cpp
@@ -1738,7 +1738,7 @@ int cthd_gddv::evaluate_condition(struct condition& condition) {
 			return ret;
 
 		if (condition.time) {
-			thd_log_debug("time condition matched %ld \n", condition.state_entry_time);
+			thd_log_debug("time condition matched %jd \n", (intmax_t)condition.state_entry_time);
 			if (condition.state_entry_time == 0) {
 				condition.state_entry_time = time(nullptr);
 				return THD_ERROR;


### PR DESCRIPTION
Fix the error caused by type mismatch:

src/thd_gddv.cpp: In member function 'int cthd_gddv::evaluate_condition(condition&)':
src/thd_gddv.cpp:1721:39: error: format '%ld' expects argument of type 'long int', but argument 4 has type 'time_t' {aka 'long long int'} [-Werror=format=]