### PR TITLE
Add Wildcat Lake to supported CPU model table

### DIFF
--- a/src/thd_platform_intel.cpp
+++ b/src/thd_platform_intel.cpp
@@ -81,6 +81,7 @@ static supported_ids_t intel_id_table[] = {
     { 6, 0xc5, 1 }, // Arrow Lake H
     { 6, 0xb5, 1 }, // Arrow Lake U
     { 6, 0xcc, 1 }, // Panther Lake L
+    { 6, 0xd5, 1 }, // Wildcat Lake L
     { 15, 0x01, 1 }, // Nova Lake S
     { 15, 0x03, 1 }, // Nova Lake U/P/H/Hx
     { 0, 0, 0 } // Last Invalid entry


### PR DESCRIPTION
Wildcat Lake (family 6, model 0xd5) is missing from `intel_id_table[]`, so `check_cpu_id()` fails to match and `cthd_engine_adaptive::thd_engine_init()` exits with "Unsupported cpu model or platform". Because that path calls `exit(EXIT_SUCCESS)`, systemd records a clean exit and `Restart=on-failure` never fires, so the unit stays enabled while doing nothing.

Marked `adaptive_only`, consistent with the other recent client platforms (Lunar Lake, Arrow Lake, Panther Lake, Nova Lake). That third field is what makes this safe to add without any silicon-specific values: thermald carries no thermal constants for these platforms and reads GDDV out of firmware at runtime, so the entry asserts only that this platform is driven by its own firmware tables.

## Platform

- Dell XPS 13 DX13260, BIOS 1.6.0
- Intel Core 5 320, family 6 model 213 (`0xD5`) stepping 1
- Kernel 7.1.6-201.fc44.x86_64, Fedora 44
- `INTC10FC:00` INT3400 with a populated 1208-byte `data_vault`, `\_SB_.IETM`
- RAPL powercap MSR + MMIO both present

Affects both Fedora's 2.5.9 package and master at `2d93d94` (2.5.12-rc1).

## Testing

Built from master `2d93d94`, installed to `/usr/local/bin` and run via a systemd drop-in.

Before: `thermald.service` exits immediately at every boot.

```
thermald[955]: 40 CPUID levels; family:model:stepping 0x6:d5:1 (6:213:1)
thermald[955]:  Need Linux PowerCap sysfs
thermald[955]: Unsupported cpu model or platform
```

After: the daemon stays running, parses this machine's GDDV, selects target `Balance Mode-28C`, and drives `rapl_controller_mmio` between the firmware's own `PL1MIN 15000` / `PL1MAX 25000`. Measured on `intel-rapl-mmio:0/constraint_0_power_limit_uw`: `15000000` before, `25000000` after.

Nothing else in the adaptive path needed changes. thermald discovers INT3400 by scanning for a driver directory entry starting with `INT`, so the newer `INTC10FC` ACPI ID is picked up as-is. `available_uuids` reads `UNKNOWN` and `current_uuid` reads `INVALID`, which matches other recent client platforms where policy comes from GDDV rather than UUID selection.

One limit worth stating: the passive throttle-down branch was not exercised. Under six cores of `openssl speed -evp aes-256-cbc` for four minutes, `SEN1` (the sensor GDDV binds the 54C passive trip to) peaked at 50C while the package reached 76C, so the trip was never crossed. That is a property of which sensor the platform's firmware selects, not of this change. Verified up to the trip, not through it.

## Note, not part of this patch

`thd_platform_intel.cpp:157` prints " Need Linux PowerCap sysfs" unconditionally on any table miss, without checking whether powercap is present. On this machine powercap is fully populated, so the message points at the wrong thing and is easy to chase for a while. Happy to send that separately if it is worth fixing.

## Unrelated

No overlap with #597, which touches the Qualcomm SPEL path in `thd_engine_default.cpp`.