### PR TITLE
Don't claim PowerCap is missing on a CPUID table miss

### DIFF
--- a/src/thd_platform_intel.cpp
+++ b/src/thd_platform_intel.cpp
@@ -155,7 +155,12 @@ int intel_platform::check_cpu_id(bool &proc_list_matched) {
         i++;
     }
     if (!valid) {
-        thd_log_msg(" Need Linux PowerCap sysfs\n");
+        csys_fs powercap_sysfs("/sys/class/powercap/intel-rapl/");
+
+        if (powercap_sysfs.exists())
+            thd_log_msg(" CPU model not in the supported list, using Linux PowerCap sysfs\n");
+        else
+            thd_log_msg(" Unsupported CPU model and no Linux PowerCap sysfs\n");
     }
 
     for (const char *path : blocklist_paths) {


### PR DESCRIPTION
`check_cpu_id()` prints " Need Linux PowerCap sysfs" on any `intel_id_table[]` miss, without checking whether powercap is actually present.

The message goes back to 9b1fae1, where it was meant to state a requirement rather than a finding: an unmatched CPU can still be driven as long as the kernel exposes powercap sysfs. It reads as a diagnosis, so on a machine where `/sys/class/powercap/intel-rapl` is fully populated it points at the wrong subsystem. I chased it for a while on an unlisted platform before finding the real cause was the missing table entry (since fixed by dd0eb7e).

This stats the path and reports whichever case applies:

| powercap sysfs | message |
|---|---|
| present | ` CPU model not in the supported list, using Linux PowerCap sysfs` |
| absent | ` Unsupported CPU model and no Linux PowerCap sysfs` |

No behavior change, `proc_list_matched` and the return value are untouched. Only the log line differs.

## Testing

Built clean on master at 19f29af.

The runtime path is hard for me to exercise honestly now: this box is Wildcat Lake, which dd0eb7e added to the table, so `!valid` is no longer reachable here. Forcing a table miss to reach it needs root and I only confirmed the pieces: `csys_fs::exists()` resolves to `stat(base_path)`, and `/sys/class/powercap/intel-rapl/` stats successfully on this machine, so it would take the first row above. Compile-tested, not run through both branches.

Follow-up to #598, which I closed as a duplicate.